### PR TITLE
Composer init

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,2 +1,5 @@
 version = "3.0.0-RC5"
 runner.dialect = scala3
+
+align.preset = more
+maxColumn = 100

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
-val scala3Version = "3.0.0"
-val projectName = "scala-yaml"
+val scala3Version  = "3.0.0"
+val projectName    = "scala-yaml"
 val projectVersion = "0.0.1"
 
-lazy val utest: Seq[Setting[_]] = Seq(
+lazy val munit: Seq[Setting[_]] = Seq(
   libraryDependencies ++= Seq(Deps.munit % Test, Deps.expecty % Test),
   testFrameworks += new TestFramework("munit.Framework")
 )
@@ -13,8 +13,7 @@ lazy val root = project
     name := projectName,
     version := projectVersion,
     scalaVersion := scala3Version,
-    scalacOptions += "-Ywarn-unused-import",
     semanticdbVersion := scalafixSemanticdb.revision,
     semanticdbEnabled := true
   )
-  .settings(utest)
+  .settings(munit)

--- a/src/main/scala/org/virtuslab/internal/YamlError.scala
+++ b/src/main/scala/org/virtuslab/internal/YamlError.scala
@@ -1,0 +1,3 @@
+package org.virtuslab.internal
+
+case class YamlError(msg: String)

--- a/src/main/scala/org/virtuslab/internal/load/compose/Composer.scala
+++ b/src/main/scala/org/virtuslab/internal/load/compose/Composer.scala
@@ -25,28 +25,23 @@ object ComposerImpl extends Composer with NodeTransform:
     yield node
 
   override def fromEvents(events: List[Event]): Either[YamlError, Node] =
-    events match {
+    events match
       case Nil =>
         Left(YamlError("No events available"))
       case _ =>
         val (node, _) = composeNode(events)
         node
-    }
 
-  private def composeNode(events: List[Event]): ComposeResult = {
-    events match {
+  private def composeNode(events: List[Event]): ComposeResult =
+    events match
       case head :: tail =>
-        head match {
+        head match
           case StreamStart | DocumentStart => composeNode(tail)
           case SequenceStart               => composeSequenceNode(tail)
           case MappingStart                => composeMappingNode(tail)
           case s: Scalar                   => (composeScalarNode(s), tail)
-          case _                           => (Left(YamlError("No events available")), events)
-        }
-      case Nil =>
-        (Left(YamlError("No events available")), events)
-    }
-  }
+          case event                       => (Left(YamlError(s"Unexpected event $event")), events)
+      case Nil => (Left(YamlError("No events available")), Nil)
 
   private def composeSequenceNode(events: List[Event]): ComposeResult = {
     @tailrec

--- a/src/main/scala/org/virtuslab/internal/load/compose/Composer.scala
+++ b/src/main/scala/org/virtuslab/internal/load/compose/Composer.scala
@@ -1,0 +1,82 @@
+package org.virtuslab.internal.load.compose
+
+import org.virtuslab.internal.load.{YamlReader, StringYamlReader}
+import org.virtuslab.internal.load.parse.Event
+import org.virtuslab.internal.YamlError
+import org.virtuslab.internal.load.parse.Event.{Node => _, *}
+import org.virtuslab.internal.load.parse.ParserImpl
+import org.virtuslab.internal.load.compose.Node.*
+import scala.annotation.tailrec
+
+trait Composer:
+  def compose(yaml: String): Either[YamlError, Node]
+  def compose(reader: YamlReader): Either[YamlError, Node]
+
+object ComposerImpl extends Composer with NodeTransform:
+
+  type ComposeResult = (Either[YamlError, Node], List[Event])
+
+  override def compose(yaml: String): Either[YamlError, Node] = compose(StringYamlReader(yaml))
+
+  override def compose(reader: YamlReader): Either[YamlError, Node] =
+    for
+      events <- ParserImpl.getEvents(reader, ???)
+      node   <- fromEvents(events)
+    yield node
+
+  override def fromEvents(events: List[Event]): Either[YamlError, Node] =
+    events match {
+      case Nil =>
+        Left(YamlError("No events available"))
+      case _ =>
+        val (node, _) = composeNode(events)
+        node
+    }
+
+  private def composeNode(events: List[Event]): ComposeResult = {
+    events match {
+      case head :: tail =>
+        head match {
+          case StreamStart | DocumentStart => composeNode(tail)
+          case SequenceStart               => composeSequenceNode(tail)
+          case MappingStart                => composeMappingNode(tail)
+          case e @ Scalar(_)               => (composeScalarNode(e), tail)
+          case _                           => (Left(YamlError("No events available")), events)
+        }
+      case Nil =>
+        (Left(YamlError("No events available")), events)
+    }
+  }
+
+  private def composeSequenceNode(events: List[Event]): ComposeResult = {
+    @tailrec
+    def parseChildren(
+        events: List[Event],
+        children: List[Node]
+    ): (Either[YamlError, List[Node]], List[Event]) = {
+      events match {
+        case Nil                 => (Left(YamlError("No events available")), events)
+        case SequenceEnd :: tail => (Right(children), tail)
+        case _ =>
+          val (node, rest) = composeNode(events)
+          node match {
+            case Right(value) => parseChildren(rest, children :+ value)
+            case Left(err)    => (Left(err), rest)
+          }
+      }
+    }
+
+    val (result, rest) = parseChildren(events, Nil)
+    val ret = for {
+      children <- result
+    } yield SequenceNode(children)
+    (ret, rest)
+  }
+
+  private def composeMappingNode(events: List[Event]): ComposeResult = {
+    ???
+  }
+
+  private def composeScalarNode(event: Scalar): Either[YamlError, Node] = Right(
+    ScalarNode(event.value)
+  )

--- a/src/main/scala/org/virtuslab/internal/load/compose/Node.scala
+++ b/src/main/scala/org/virtuslab/internal/load/compose/Node.scala
@@ -6,11 +6,13 @@ object Node:
   case class ScalarNode(value: String) extends Node
 
   case class SequenceNode(nodes: Seq[Node]) extends Node
-  case object SequenceNode:
+  object SequenceNode:
     final val empty: SequenceNode = SequenceNode(Seq.empty)
+    def apply(node: Node, nodes: Node*): SequenceNode = SequenceNode(node :: nodes.toList)
 
   case class MappingNode(mappings: Seq[Mapping]) extends Node
-  case object MappingNode:
+  object MappingNode:
     final val empty: MappingNode = MappingNode(Seq.empty)
+    def apply(node: Mapping, nodes: Mapping*): MappingNode = MappingNode(node :: nodes.toList)
 
   case class Mapping(key: ScalarNode, value: Node) extends Node

--- a/src/main/scala/org/virtuslab/internal/load/compose/Node.scala
+++ b/src/main/scala/org/virtuslab/internal/load/compose/Node.scala
@@ -3,14 +3,14 @@ package org.virtuslab.internal.load.compose
 sealed trait Node
 
 object Node:
-  case class Scalar(value: String) extends Node
+  case class ScalarNode(value: String) extends Node
 
   case class SequenceNode(nodes: Seq[Node]) extends Node
   case object SequenceNode:
     final val empty: SequenceNode = SequenceNode(Seq.empty)
 
-  case class MappingdNode(mappings: Seq[Mapping]) extends Node
+  case class MappingNode(mappings: Seq[Mapping]) extends Node
   case object MappingNode:
-    final val empty: MappingdNode = MappingdNode(Seq.empty)
+    final val empty: MappingNode = MappingNode(Seq.empty)
 
-  case class Mapping(key: Scalar, value: Node) extends Node
+  case class Mapping(key: ScalarNode, value: Node) extends Node

--- a/src/main/scala/org/virtuslab/internal/load/compose/Node.scala
+++ b/src/main/scala/org/virtuslab/internal/load/compose/Node.scala
@@ -10,9 +10,9 @@ object Node:
     final val empty: SequenceNode = SequenceNode(Seq.empty)
     def apply(node: Node, nodes: Node*): SequenceNode = SequenceNode(node :: nodes.toList)
 
-  case class MappingNode(mappings: Seq[Mapping]) extends Node
+  case class MappingNode(mappings: Seq[KeyValueNode]) extends Node
   object MappingNode:
     final val empty: MappingNode = MappingNode(Seq.empty)
-    def apply(node: Mapping, nodes: Mapping*): MappingNode = MappingNode(node :: nodes.toList)
+    def apply(node: KeyValueNode, nodes: KeyValueNode*): MappingNode = MappingNode(node :: nodes.toList)
 
-  case class Mapping(key: ScalarNode, value: Node) extends Node
+  case class KeyValueNode(key: ScalarNode, value: Node) extends Node

--- a/src/main/scala/org/virtuslab/internal/load/compose/NodeTransform.scala
+++ b/src/main/scala/org/virtuslab/internal/load/compose/NodeTransform.scala
@@ -1,6 +1,7 @@
 package org.virtuslab.internal.load.compose
 
 import org.virtuslab.internal.load.parse.Event
+import org.virtuslab.internal.YamlError
 
 trait NodeTransform:
-  def fromEvents(events: Seq[Event]): Either[Any, Node]
+  def fromEvents(events: List[Event]): Either[YamlError, Node]

--- a/src/main/scala/org/virtuslab/internal/load/compose/NodeTransformer.scala
+++ b/src/main/scala/org/virtuslab/internal/load/compose/NodeTransformer.scala
@@ -1,8 +1,0 @@
-package org.virtuslab.internal.load.compose
-
-import org.virtuslab.internal.load.parse.Event
-
-import scala.annotation.tailrec
-
-object NodeTransformer extends NodeTransform:
-  override def fromEvents(events: Seq[Event]): Either[Any, Node] = ???

--- a/src/main/scala/org/virtuslab/internal/load/parse/Event.scala
+++ b/src/main/scala/org/virtuslab/internal/load/parse/Event.scala
@@ -1,10 +1,11 @@
 package org.virtuslab.internal.load.parse
 
-/** Valid sequence of events should obey following grammar stream ::=
-  * STREAM-START document* STREAM-END document ::= DOCUMENT-START node
-  * DOCUMENT-END node ::= ALIAS | SCALAR | sequence | mapping sequence ::=
-  * SEQUENCE-START node* SEQUENCE-END mapping ::= MAPPING-START (node node)*
-  * MAPPING-END
+/** Valid sequence of events should obey following grammar 
+  * stream ::= STREAM-START document* STREAM-END 
+  * document ::= DOCUMENT-START node DOCUMENT-END 
+  * node ::= ALIAS | SCALAR | sequence | mapping 
+  * sequence ::= SEQUENCE-START node* SEQUENCE-END 
+  * mapping ::= MAPPING-START (node node)* MAPPING-END
   */
 
 sealed trait Event

--- a/src/main/scala/org/virtuslab/internal/load/parse/ParserImpl.scala
+++ b/src/main/scala/org/virtuslab/internal/load/parse/ParserImpl.scala
@@ -2,11 +2,12 @@ package org.virtuslab.internal.load.parse
 
 import scala.annotation.tailrec
 import org.virtuslab.internal.load.YamlReader
+import org.virtuslab.internal.YamlError
 
 object ParserImpl extends Parser:
   def getEvents(
       in: YamlReader,
       ctx: ParserCtx
-  ): Either[ParserError, List[Event]] = ???
+  ): Either[YamlError, List[Event]] = ???
 
   def getNextEvent(in: YamlReader, ctx: ParserCtx): (Event, ParserCtx) = ???

--- a/src/main/scala/org/virtuslab/internal/load/parse/ParserState.scala
+++ b/src/main/scala/org/virtuslab/internal/load/parse/ParserState.scala
@@ -1,15 +1,14 @@
 package org.virtuslab.internal.load.parse
 
 import org.virtuslab.internal.load.YamlReader
-
-sealed trait ParserError
+import org.virtuslab.internal.YamlError
 
 case class ParserCtx(
     state: ParserState
 )
 
 trait Parser:
-  def getEvents(in: YamlReader, ctx: ParserCtx): Either[ParserError, Seq[Event]]
+  def getEvents(in: YamlReader, ctx: ParserCtx): Either[YamlError, Seq[Event]]
 
 /** Valid sequence of events should obey following grammar so parser states
   * should mirror that grammar stream ::= STREAM-START document* STREAM-END

--- a/src/main/scala/org/virtuslab/yaml/YamlDecoder.scala
+++ b/src/main/scala/org/virtuslab/yaml/YamlDecoder.scala
@@ -6,19 +6,19 @@ import scala.compiletime._
 import org.virtuslab.internal.load.parse.ParserImpl
 import org.virtuslab.internal.load.YamlReader
 import org.virtuslab.internal.load.StringYamlReader
-import org.virtuslab.internal.load.compose.NodeTransformer
 import org.virtuslab.internal.load.construct.Construct
 import org.virtuslab.internal.load.compose.Node
+import org.virtuslab.internal.YamlError
+import org.virtuslab.internal.load.compose.ComposerImpl
 
 trait YamlDecoder[T: Mirror.Of]:
 
   given yamlWriter: Construct[T] = Construct.derived[T]
 
-  final def from(yaml: String): Either[Any, T] =
-    for {
-      events <- ParserImpl.getEvents(StringYamlReader(yaml), ???)
-      node <- NodeTransformer.fromEvents(events)
-    } yield apply(node)
+  final def from(yaml: String): Either[YamlError, T] =
+    for
+      node <- ComposerImpl.compose(yaml)
+    yield apply(node)
 
   def apply(node: Node): T = ???
 

--- a/src/main/scala/org/virtuslab/yaml/yaml.scala
+++ b/src/main/scala/org/virtuslab/yaml/yaml.scala
@@ -1,12 +1,16 @@
 package org.virtuslab.scala.yaml
 
 import org.virtuslab.yaml.{YamlDecoder, YamlEncoder}
+import org.virtuslab.internal.load.compose.Node
+import org.virtuslab.internal.load.compose.ComposerImpl
+import org.virtuslab.internal.YamlError
 
 import scala.deriving._
 
 def deriveEncoder[T](using m: Mirror.Of[T]) = YamlEncoder.derived
 def deriveDecoder[T](using m: Mirror.Of[T]) = YamlDecoder.derived
 
+def parse(yaml: String): Either[YamlError, Node] = ComposerImpl.compose(yaml)
 extension (str: String)
   def fromYaml[T](using decoder: YamlDecoder[T]): Either[Any, T] = decoder.from(str)
 

--- a/src/test/scala/org/virtuslab/internal/load/compose/ComposerSpec.scala
+++ b/src/test/scala/org/virtuslab/internal/load/compose/ComposerSpec.scala
@@ -4,9 +4,11 @@ import org.virtuslab.internal.load.compose.ComposerImpl
 import org.virtuslab.internal.load.parse.Event.*
 import org.virtuslab.internal.load.compose.Node.*
 
+/** Examples taken from https://yaml.org/spec/1.2/spec.html#id2759963
+  */
 class ComposerSuite extends munit.FunSuite:
 
-  test("compose-sequence") {
+  test("sequence of scalars") {
     val events = List(
       StreamStart,
       DocumentStart,
@@ -20,13 +22,16 @@ class ComposerSuite extends munit.FunSuite:
     )
     val expected = Right(
       SequenceNode(
-        List(ScalarNode("Mark McGwire"), ScalarNode("Sammy Sosa"), ScalarNode("Ken Griffey"))
+        ScalarNode("Mark McGwire"),
+        ScalarNode("Sammy Sosa"),
+        ScalarNode("Ken Griffey")
       )
     )
+
     assertEquals(ComposerImpl.fromEvents(events), expected)
   }
 
-  test("compose-mapping") {
+  test("mapping of scalars") {
     val events = List(
       StreamStart,
       DocumentStart,
@@ -41,16 +46,103 @@ class ComposerSuite extends munit.FunSuite:
       DocumentEnd,
       StreamEnd
     )
+    val expected = Right(
+      MappingNode(
+        Mapping(ScalarNode("hr"), ScalarNode("65")),
+        Mapping(ScalarNode("avg"), ScalarNode("0.278")),
+        Mapping(ScalarNode("rbi"), ScalarNode("147"))
+      )
+    )
 
+    assertEquals(ComposerImpl.fromEvents(events), expected)
+  }
+
+  test("mapping of sequences") {
+    val events = List(
+      StreamStart,
+      DocumentStart,
+      MappingStart,
+      Scalar("american"),
+      SequenceStart,
+      Scalar("Boston Red Sox"),
+      Scalar("Detroit Tigers"),
+      Scalar("New York Yankees"),
+      SequenceEnd,
+      Scalar("national"),
+      SequenceStart,
+      Scalar("New York Mets"),
+      Scalar("Chicago Cubs"),
+      Scalar("Atlanta Braves"),
+      SequenceEnd,
+      MappingEnd,
+      DocumentEnd,
+      StreamEnd
+    )
     val expected = Right(
       MappingNode(
         List(
-          Mapping(ScalarNode("hr"), ScalarNode("65")),
-          Mapping(ScalarNode("avg"), ScalarNode("0.278")),
-          Mapping(ScalarNode("rbi"), ScalarNode("147"))
+          Mapping(
+            ScalarNode("american"),
+            SequenceNode(
+              ScalarNode("Boston Red Sox"),
+              ScalarNode("Detroit Tigers"),
+              ScalarNode("New York Yankees")
+            )
+          ),
+          Mapping(
+            ScalarNode("national"),
+            SequenceNode(
+              ScalarNode("New York Mets"),
+              ScalarNode("Chicago Cubs"),
+              ScalarNode("Atlanta Braves")
+            )
+          )
         )
       )
     )
 
+    assertEquals(ComposerImpl.fromEvents(events), expected)
+  }
+
+  test("sequence of mappings") {
+    val events = List(
+      StreamStart,
+      DocumentStart,
+      SequenceStart,
+      MappingStart,
+      Scalar("name"),
+      Scalar("Mark McGwire"),
+      Scalar("hr"),
+      Scalar("65"),
+      Scalar("avg"),
+      Scalar("0.278"),
+      MappingEnd,
+      MappingStart,
+      Scalar("name"),
+      Scalar("Sammy Sosa"),
+      Scalar("hr"),
+      Scalar("63"),
+      Scalar("avg"),
+      Scalar("0.288"),
+      MappingEnd,
+      SequenceEnd,
+      DocumentEnd,
+      StreamEnd
+    )
+    val expected = Right(
+      SequenceNode(
+        MappingNode(
+          Mapping(ScalarNode("name"), ScalarNode("Mark McGwire")),
+          Mapping(ScalarNode("hr"), ScalarNode("65")),
+          Mapping(ScalarNode("avg"), ScalarNode("0.278"))
+        ),
+        MappingNode(
+          Mapping(ScalarNode("name"), ScalarNode("Sammy Sosa")),
+          Mapping(ScalarNode("hr"), ScalarNode("63")),
+          Mapping(ScalarNode("avg"), ScalarNode("0.288"))
+        )
+      )
+    )
+    
     assertEquals(ComposerImpl.fromEvents(events), expected)
   }

--- a/src/test/scala/org/virtuslab/internal/load/compose/ComposerSpec.scala
+++ b/src/test/scala/org/virtuslab/internal/load/compose/ComposerSpec.scala
@@ -6,7 +6,7 @@ import org.virtuslab.internal.load.compose.Node.*
 
 class ComposerSuite extends munit.FunSuite:
 
-  test("compose-sequence".only) {
+  test("compose-sequence") {
     val events = List(
       StreamStart,
       DocumentStart,
@@ -25,7 +25,6 @@ class ComposerSuite extends munit.FunSuite:
     )
     assertEquals(ComposerImpl.fromEvents(events), expected)
   }
-
 
   test("compose-mapping") {
     val events = List(

--- a/src/test/scala/org/virtuslab/internal/load/compose/ComposerSpec.scala
+++ b/src/test/scala/org/virtuslab/internal/load/compose/ComposerSpec.scala
@@ -1,0 +1,57 @@
+package org.virtuslab.internal.load.compose
+
+import org.virtuslab.internal.load.compose.ComposerImpl
+import org.virtuslab.internal.load.parse.Event.*
+import org.virtuslab.internal.load.compose.Node.*
+
+class ComposerSuite extends munit.FunSuite:
+
+  test("compose-sequence".only) {
+    val events = List(
+      StreamStart,
+      DocumentStart,
+      SequenceStart,
+      Scalar("Mark McGwire"),
+      Scalar("Sammy Sosa"),
+      Scalar("Ken Griffey"),
+      SequenceEnd,
+      DocumentEnd,
+      StreamEnd
+    )
+    val expected = Right(
+      SequenceNode(
+        List(ScalarNode("Mark McGwire"), ScalarNode("Sammy Sosa"), ScalarNode("Ken Griffey"))
+      )
+    )
+    assertEquals(ComposerImpl.fromEvents(events), expected)
+  }
+
+
+  test("compose-mapping") {
+    val events = List(
+      StreamStart,
+      DocumentStart,
+      MappingStart,
+      Scalar("hr"),
+      Scalar("65"),
+      Scalar("avg"),
+      Scalar("0.278"),
+      Scalar("rbi"),
+      Scalar("147"),
+      MappingEnd,
+      DocumentEnd,
+      StreamEnd
+    )
+
+    val expected = Right(
+      MappingNode(
+        List(
+          Mapping(ScalarNode("hr"), ScalarNode("65")),
+          Mapping(ScalarNode("avg"), ScalarNode("0.278")),
+          Mapping(ScalarNode("rbi"), ScalarNode("147"))
+        )
+      )
+    )
+
+    assertEquals(ComposerImpl.fromEvents(events), expected)
+  }

--- a/src/test/scala/org/virtuslab/internal/load/compose/ComposerSpec.scala
+++ b/src/test/scala/org/virtuslab/internal/load/compose/ComposerSpec.scala
@@ -48,9 +48,9 @@ class ComposerSuite extends munit.FunSuite:
     )
     val expected = Right(
       MappingNode(
-        Mapping(ScalarNode("hr"), ScalarNode("65")),
-        Mapping(ScalarNode("avg"), ScalarNode("0.278")),
-        Mapping(ScalarNode("rbi"), ScalarNode("147"))
+        KeyValueNode(ScalarNode("hr"), ScalarNode("65")),
+        KeyValueNode(ScalarNode("avg"), ScalarNode("0.278")),
+        KeyValueNode(ScalarNode("rbi"), ScalarNode("147"))
       )
     )
 
@@ -81,7 +81,7 @@ class ComposerSuite extends munit.FunSuite:
     val expected = Right(
       MappingNode(
         List(
-          Mapping(
+          KeyValueNode(
             ScalarNode("american"),
             SequenceNode(
               ScalarNode("Boston Red Sox"),
@@ -89,7 +89,7 @@ class ComposerSuite extends munit.FunSuite:
               ScalarNode("New York Yankees")
             )
           ),
-          Mapping(
+          KeyValueNode(
             ScalarNode("national"),
             SequenceNode(
               ScalarNode("New York Mets"),
@@ -132,14 +132,14 @@ class ComposerSuite extends munit.FunSuite:
     val expected = Right(
       SequenceNode(
         MappingNode(
-          Mapping(ScalarNode("name"), ScalarNode("Mark McGwire")),
-          Mapping(ScalarNode("hr"), ScalarNode("65")),
-          Mapping(ScalarNode("avg"), ScalarNode("0.278"))
+          KeyValueNode(ScalarNode("name"), ScalarNode("Mark McGwire")),
+          KeyValueNode(ScalarNode("hr"), ScalarNode("65")),
+          KeyValueNode(ScalarNode("avg"), ScalarNode("0.278"))
         ),
         MappingNode(
-          Mapping(ScalarNode("name"), ScalarNode("Sammy Sosa")),
-          Mapping(ScalarNode("hr"), ScalarNode("63")),
-          Mapping(ScalarNode("avg"), ScalarNode("0.288"))
+          KeyValueNode(ScalarNode("name"), ScalarNode("Sammy Sosa")),
+          KeyValueNode(ScalarNode("hr"), ScalarNode("63")),
+          KeyValueNode(ScalarNode("avg"), ScalarNode("0.288"))
         )
       )
     )


### PR DESCRIPTION
Implementation of [compose phase](https://yaml.org/spec/1.2/spec.html#id2762107).  
The composer task is to produce a node graph (think of it as a JSON AST) from a stream of events. At now it's a very straightforward implementation that doesn't take into account any metadata information (because Tokens don't have it too), but this will change with improvements of the parser stage.  
Also, error handling is not the best one, but I think it's good enough for the first iteration.
 