### PR TITLE
Fix scenario 'Spec Example 7.11. Plain Implicit Keys'

### DIFF
--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -29,8 +29,8 @@ object BuildHelper {
   )
 
   lazy val testSettings: Seq[Setting[_]] = Seq(
-      publish / skip := true,
-      libraryDependencies ++= Seq(Deps.osLib, Deps.munit)
+    publish / skip := true,
+    libraryDependencies ++= Seq(Deps.osLib, Deps.munit)
   ) ++ munit
 
   lazy val munit: Seq[Setting[_]] = Seq(

--- a/tests/test-core/shared/src/main/scala/org/virtuslab/yaml/ConfigTestRunner.scala
+++ b/tests/test-core/shared/src/main/scala/org/virtuslab/yaml/ConfigTestRunner.scala
@@ -12,32 +12,15 @@ import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle._
 import org.virtuslab.yaml.internal.load.reader.token.Token._
 
-case class ConfigTestRunner(yamlPath: os.Path, libYaml: os.Path) extends TestRunner {
+case class ConfigTestRunner(yamlPath: os.Path, libYaml: os.Path) extends TestRunner:
+  override val inYaml = os.read(yamlPath)
+  override val expectedEvents = os
+    .proc(libYaml, yamlPath)
+    .call(cwd = os.pwd)
+    .out
+    .text()
+    .trim
 
-  def run(): RunnerResult = {
+  override def run(): RunnerResult =
     println(yamlPath)
-    val yaml   = os.read(yamlPath)
-    val reader = Scanner(yaml)
-
-    ParserImpl(reader).getEvents() match {
-      case Right(events) => {
-        val eventYamlTestSuite: String = TestRunnerUtils.convertEventToYamlTestSuiteFormat(events)
-        val libYamlEvent               = eventFromLibYaml
-
-        RunnerResult.Success(eventYamlTestSuite, libYamlEvent)
-      }
-      case Left(e) => RunnerResult.Exeception(e)
-    }
-
-  }
-
-  private def eventFromLibYaml: String = {
-    os
-      .proc(libYaml, yamlPath)
-      .call(cwd = os.pwd)
-      .out
-      .text()
-      .trim
-  }
-
-}
+    super.run()

--- a/tests/test-core/shared/src/main/scala/org/virtuslab/yaml/RunnerResult.scala
+++ b/tests/test-core/shared/src/main/scala/org/virtuslab/yaml/RunnerResult.scala
@@ -5,9 +5,9 @@ trait RunnerResult:
 
 case object RunnerResult:
 
-  case class Success(events: String, expectedEvents: String) extends RunnerResult {
+  case class Success(events: String, expectedEvents: String) extends RunnerResult:
     override def isValid: Boolean = events == expectedEvents
-  }
-  case class Exeception(yamlError: YamlError) extends RunnerResult {
-    override def isValid: Boolean = false
-  }
+
+  case class Exception(events: String, yamlError: YamlError) extends RunnerResult:
+    override val isValid: Boolean = false
+end RunnerResult

--- a/tests/test-core/shared/src/main/scala/org/virtuslab/yaml/TestRunner.scala
+++ b/tests/test-core/shared/src/main/scala/org/virtuslab/yaml/TestRunner.scala
@@ -1,4 +1,43 @@
 package org.virtuslab.yaml
 
-trait TestRunner:
-  def run(): RunnerResult
+import org.virtuslab.yaml.internal.load.parse.ParserImpl
+
+import scala.util.{Failure, Success, Try}
+
+import org.virtuslab.yaml
+import org.virtuslab.yaml.internal.load.parse.Event._
+import org.virtuslab.yaml.internal.load.parse.{Event, ParserImpl}
+import org.virtuslab.yaml.internal.load.reader.Scanner
+import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
+import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle._
+import org.virtuslab.yaml.internal.load.reader.token.Token._
+import scala.annotation.tailrec
+import scala.collection.mutable
+
+trait TestRunner():
+  def inYaml: String
+  def expectedEvents: String
+
+  def run(): RunnerResult =
+    val reader = Scanner(inYaml)
+    val parser = ParserImpl(reader)
+    val acc    = new mutable.ArrayDeque[Event](50)
+
+    @tailrec
+    def loop(): RunnerResult = {
+      parser.getNextEvent() match
+        case Right(event) =>
+          acc.append(event)
+          if event != Event.StreamEnd then loop()
+          else
+            val events   = TestRunnerUtils.convertEventToYamlTestSuiteFormat(acc.toSeq)
+            val expected = expectedEvents
+            RunnerResult.Success(events, expected)
+        case Left(e) =>
+          val events = TestRunnerUtils.convertEventToYamlTestSuiteFormat(acc.toSeq)
+          RunnerResult.Exception(events, e)
+    }
+    loop()
+  end run
+
+end TestRunner

--- a/tests/test-core/shared/src/main/scala/org/virtuslab/yaml/TestRunnerUtils.scala
+++ b/tests/test-core/shared/src/main/scala/org/virtuslab/yaml/TestRunnerUtils.scala
@@ -3,12 +3,12 @@ package org.virtuslab.yaml
 import org.virtuslab.yaml.internal.load.parse.Event
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 
-object TestRunnerUtils {
+object TestRunnerUtils:
 
-  def convertEventToYamlTestSuiteFormat(event: List[Event]): String = {
+  def convertEventToYamlTestSuiteFormat(event: Seq[Event]): String =
     event
       .map(event =>
-        event match {
+        event match
           case _: Event.StreamStart             => "+STR"
           case _: Event.StreamEnd               => "-STR"
           case Event.DocumentStart(_, explicit) => if (explicit) "+DOC ---" else "+DOC"
@@ -25,8 +25,7 @@ object TestRunnerUtils {
               case ScalarStyle.Folded       => s"=VAL >$value"
               case ScalarStyle.Literal      => s"=VAL |$value"
             }
-        }
       )
       .mkString("\n")
-  }
-}
+
+end TestRunnerUtils

--- a/tests/test-core/shared/src/main/scala/org/virtuslab/yaml/TestSuiteRunner.scala
+++ b/tests/test-core/shared/src/main/scala/org/virtuslab/yaml/TestSuiteRunner.scala
@@ -11,19 +11,12 @@ import org.virtuslab.yaml.internal.load.reader.Scanner
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle._
 import org.virtuslab.yaml.internal.load.reader.token.Token._
+import scala.annotation.tailrec
+import scala.collection.mutable
 
 case class TestSuiteRunner(testYamlML: os.Path) extends TestRunner {
+  private val testMl = TestMlEntry.from(os.read(testYamlML))
 
-  override def run(): RunnerResult =
-    val testMl = TestMlEntry.from(os.read(testYamlML))
-    val reader = Scanner(testMl.inYaml)
-
-    ParserImpl(reader).getEvents() match
-      case Right(events) =>
-        val eventYamlTestSuite  = TestRunnerUtils.convertEventToYamlTestSuiteFormat(events)
-        val testSuiteYamlEvents = testMl.seqEvent
-
-        RunnerResult.Success(eventYamlTestSuite, testSuiteYamlEvents)
-      case Left(e) => RunnerResult.Exeception(e)
-
+  override val inYaml         = testMl.inYaml
+  override val expectedEvents = testMl.seqEvent
 }

--- a/tests/test-suite/jvm/src/it/scala/org/virtuslab/yaml/YamlRunnerSpec.scala
+++ b/tests/test-suite/jvm/src/it/scala/org/virtuslab/yaml/YamlRunnerSpec.scala
@@ -17,6 +17,7 @@ abstract class YamlRunnerSpec extends munit.FunSuite {
       paths match {
         case path :: tail => {
 
+          println(s"Test - $path")
           val runnerResult = createTestRunner(path).run()
 
           if (runnerResult.isValid) {

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
@@ -44,4 +44,6 @@ object Event:
   case class MappingStart(pos: Option[Position] = None)     extends Mapping
   case class MappingEnd(pos: Option[Position] = None)       extends Mapping
   case class FlowMappingStart(pos: Option[Position] = None) extends Mapping
+  object FlowMappingStart                                   extends FlowMappingStart(None)
   case class FlowMappingEnd(pos: Option[Position] = None)   extends Mapping
+  object FlowMappingEnd                                     extends FlowMappingEnd(None)

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
@@ -9,6 +9,7 @@ trait Reader:
   def read(): Char
   def peek(n: Int = 0): Option[Char]
   def peekNext(): Option[Char]
+  def checkNext(predicate: Char => Boolean): Boolean
   def peekN(n: Int): String
   def isWhitespace: Boolean
   def isNextWhitespace: Boolean
@@ -32,6 +33,8 @@ private[yaml] class StringReader(in: String) extends Reader:
   override def peek(n: Int = 0): Option[Char] =
     if offset + n < in.length then Some(in.charAt(offset + n))
     else None
+
+  override def checkNext(predicate: Char => Boolean) = peekNext().exists(predicate)
 
   override def peekNext(): Option[Char] = peek(1)
   override def peekN(n: Int): String    = (0 until n).map(peek(_)).flatten.mkString("")

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/ReaderState.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/ReaderState.scala
@@ -3,9 +3,9 @@ package org.virtuslab.yaml.internal.load.reader
 sealed trait ReaderState:
   def indent: Int
 
-case object ReaderState:
-  final case class Document(indent: Int)     extends ReaderState
+object ReaderState:
   final case class Mapping(indent: Int)      extends ReaderState
   final case class Sequence(indent: Int)     extends ReaderState
+
   final case class FlowMapping(indent: Int)  extends ReaderState
   final case class FlowSequence(indent: Int) extends ReaderState

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
@@ -39,7 +39,7 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
       case Some('}')                        => parseFlowMappingEnd()
       case Some(',')                        => { in.skipCharacter(); getNextTokens() }
       case Some(_)                          => fetchValue()
-      case None => ctx.closeOpenedScopes() :+ Token.StreamEnd((in.pos()))
+      case None                             => parseStreamEnd()
 
   private def isDocumentStart =
     in.peekN(3) == "---" && in.peek(3).exists(_.isWhitespace)
@@ -54,6 +54,9 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
   private def parseDocumentEnd(): List[Token] =
     in.skipN(4)
     ctx.parseDocumentEnd()
+
+  private def parseStreamEnd(): List[Token] =
+    ctx.parseStreamEnd()
 
   private def parseFlowSequenceStart() =
     in.skipCharacter()
@@ -155,8 +158,8 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
         case None => sb.result()
 
     val scalar         = readLiteral()
-    val choompedScalar = chompingIndicator.removeBlankLinesAtEnd(scalar)
-    Scalar(choompedScalar, ScalarStyle.Literal, pos)
+    val chompedScalar = chompingIndicator.removeBlankLinesAtEnd(scalar)
+    Scalar(chompedScalar, ScalarStyle.Literal, pos)
 
   private def parseFoldedValue(): Token =
     val sb = new StringBuilder
@@ -199,8 +202,8 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
         case None => sb.result()
 
     val scalar         = readFolded()
-    val choompedScalar = chompingIndicator.removeBlankLinesAtEnd(scalar)
-    Scalar(choompedScalar, ScalarStyle.Folded, pos)
+    val chompedScalar = chompingIndicator.removeBlankLinesAtEnd(scalar)
+    Scalar(chompedScalar, ScalarStyle.Folded, pos)
 
   private def parseSingleQuoteValue(): Token = {
     val sb = new StringBuilder

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/BaseParseSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/BaseParseSuite.scala
@@ -2,6 +2,7 @@ package org.virtuslab.yaml.internal.load.parse
 
 import org.virtuslab.yaml.YamlError
 import org.virtuslab.yaml.internal.load.parse.Event.*
+import org.virtuslab.yaml.internal.load.reader.Scanner
 
 class BaseParseSuite extends munit.FunSuite:
 
@@ -31,3 +32,9 @@ class BaseParseSuite extends munit.FunSuite:
     )
     val expected = Right(expectedEvents)
     assertEquals(withoutPosition, expected)
+
+  extension (yaml: String)
+    def events: Either[YamlError, List[Event]] = {
+      val reader = Scanner(yaml)
+      ParserImpl(reader).getEvents()
+    }

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/CommentSpec.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/CommentSpec.scala
@@ -12,9 +12,6 @@ class CommentSpec extends BaseParseSuite:
           |apiVersion: apps/v1  app # comment
           |""".stripMargin
 
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
-
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
@@ -25,16 +22,13 @@ class CommentSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse empty document".ignore) {
     val yaml =
       s"""|#Comment.
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = Right(
       List(
@@ -43,7 +37,7 @@ class CommentSpec extends BaseParseSuite:
         StreamEnd
       )
     )
-    assertEquals(events, expectedEvents)
+    assertEquals(yaml.events, expectedEvents)
   }
 
   test("should parse mapping with comments") {
@@ -55,9 +49,6 @@ class CommentSpec extends BaseParseSuite:
           |  # an external load-balanced IP for the frontend service.
           |  # type: LoadBalancer
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -72,5 +63,5 @@ class CommentSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/DocumentStartEndSpec.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/DocumentStartEndSpec.scala
@@ -11,9 +11,6 @@ class DocumentStartEndSpec extends BaseParseSuite:
           |k1: v1
           |""".stripMargin
 
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
-
     val expectedEvents = List(
       StreamStart,
       DocumentStart(explicit = true),
@@ -24,7 +21,7 @@ class DocumentStartEndSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse explicit document end event") {
@@ -32,9 +29,6 @@ class DocumentStartEndSpec extends BaseParseSuite:
       s"""|k1: v1
           |...
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -46,16 +40,13 @@ class DocumentStartEndSpec extends BaseParseSuite:
       DocumentEnd(explicit = true),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse implicit document start event") {
     val yaml =
       s"""|k1: v1
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -67,7 +58,7 @@ class DocumentStartEndSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse implicit and multiple explicit document starts") {
@@ -81,9 +72,6 @@ class DocumentStartEndSpec extends BaseParseSuite:
           |k3: v3
           |...
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -107,7 +95,7 @@ class DocumentStartEndSpec extends BaseParseSuite:
       DocumentEnd(explicit = true),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse multiple explicit document's start events") {
@@ -117,9 +105,6 @@ class DocumentStartEndSpec extends BaseParseSuite:
           |---
           |k2: v2
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -137,5 +122,5 @@ class DocumentStartEndSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/MappingSpec.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/MappingSpec.scala
@@ -7,9 +7,7 @@ import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 class MappingSpec extends BaseParseSuite:
 
   test("should parse empty mapping") {
-    val yaml   = "emptyDir: {}"
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
+    val yaml = "emptyDir: {}"
 
     val expectedEvents = List(
       StreamStart,
@@ -22,7 +20,7 @@ class MappingSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse mapping with double quote key") {
@@ -30,8 +28,6 @@ class MappingSpec extends BaseParseSuite:
       s"""|data:
          |  "19": xw==
          |""".stripMargin
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -46,13 +42,11 @@ class MappingSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse nested empty mapping") {
-    val yaml   = "emptyDir: {{{}}}"
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
+    val yaml = "emptyDir: {{{}}}"
 
     val expectedEvents = List(
       StreamStart,
@@ -71,7 +65,7 @@ class MappingSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse mapping with empty value") {
@@ -79,8 +73,6 @@ class MappingSpec extends BaseParseSuite:
       s"""key: 
          |key2: value
          |""".stripMargin
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -94,7 +86,7 @@ class MappingSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse mapping with empty value and comnent") {
@@ -102,8 +94,6 @@ class MappingSpec extends BaseParseSuite:
                   |
                   |# Commnet.
                   |period: 10""".stripMargin
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -117,14 +107,12 @@ class MappingSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse yaml with template value") {
 
-    val yaml   = "replicas: {{replicas}}"
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
+    val yaml = "replicas: {{replicas}}"
 
     val expectedEvents = List(
       StreamStart,
@@ -142,13 +130,11 @@ class MappingSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse maping of mappings with {...}") {
-    val yaml   = "hostPath: {key: value, path: /dev/log}"
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
+    val yaml = "hostPath: {key: value, path: /dev/log}"
 
     val expectedEvents = List(
       StreamStart,
@@ -165,12 +151,10 @@ class MappingSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
   test("should parse maping key value with } brackets") {
-    val yaml   = "name: etcd-{{cell}}"
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
+    val yaml = "name: etcd-{{cell}}"
 
     val expectedEvents = List(
       StreamStart,
@@ -182,5 +166,5 @@ class MappingSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/ParserSpec.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/ParserSpec.scala
@@ -264,3 +264,63 @@ class ParserSpec extends BaseParseSuite:
 
     assertEventsEquals(events, expectedEvents)
   }
+
+  test("should parse") {
+    val yaml = """implicit block key : [
+                 |  implicit flow key : value,
+                 |]""".stripMargin
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      MappingStart(),
+      Scalar("implicit block key"),
+      SequenceStart(),
+      MappingStart(),
+      Scalar("implicit flow key"),
+      Scalar("value"),
+      MappingEnd(),
+      SequenceEnd(),
+      MappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    val events = yaml.events
+    println(events)
+    assertEventsEquals(events, expectedEvents)
+  }
+
+  test("should parse mapping key with additional space before ':'") {
+    val yaml = "key : value"
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      MappingStart(),
+      Scalar("key"),
+      Scalar("value"),
+      MappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  test("should parse flow sequence with comma") {
+    val yaml = "[ k: v,]"
+
+    val expectedEvents: List[Event] = List(
+      StreamStart,
+      DocumentStart(),
+      SequenceStart(),
+      MappingStart(),
+      Scalar("k"),
+      Scalar("v"),
+      MappingEnd(),
+      SequenceEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+
+    assertEventsEquals(yaml.events, expectedEvents)
+  }

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/ParserSpec.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/ParserSpec.scala
@@ -12,9 +12,6 @@ class ParserSpec extends BaseParseSuite:
                   |- Sammy Sosa
                   |- Ken Griffey""".stripMargin
 
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
-
     val expectedEvents = List(
       Event.StreamStart,
       Event.DocumentStart(),
@@ -27,7 +24,7 @@ class ParserSpec extends BaseParseSuite:
       Event.StreamEnd
     )
 
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse mapping scalars to scalars") {
@@ -35,9 +32,6 @@ class ParserSpec extends BaseParseSuite:
       s"""hr:  65
          |avg: 0.278
          |rbi: 147""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -54,7 +48,7 @@ class ParserSpec extends BaseParseSuite:
       StreamEnd
     )
 
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse sequence of mapping") {
@@ -67,9 +61,6 @@ class ParserSpec extends BaseParseSuite:
                   |  hr:   63
                   |  avg:  0.288
                   |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       Event.StreamStart,
@@ -96,7 +87,7 @@ class ParserSpec extends BaseParseSuite:
       Event.StreamEnd
     )
 
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("mapping scalar to sequences") {
@@ -109,9 +100,6 @@ class ParserSpec extends BaseParseSuite:
                   |  - Chicago Cubs
                   |  - Atlanta Braves
                   |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -134,7 +122,7 @@ class ParserSpec extends BaseParseSuite:
       StreamEnd
     )
 
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse mapping of sequence") {
@@ -145,9 +133,6 @@ class ParserSpec extends BaseParseSuite:
                   |  volumes:
                   |  - name: iscsipd-rw
                   |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -175,7 +160,7 @@ class ParserSpec extends BaseParseSuite:
       StreamEnd
     )
 
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse kubernetess config") {
@@ -199,9 +184,6 @@ class ParserSpec extends BaseParseSuite:
                   |      fsType: ext4
                   |      readOnly: true
                   |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -262,7 +244,7 @@ class ParserSpec extends BaseParseSuite:
       StreamEnd
     )
 
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse") {
@@ -286,7 +268,7 @@ class ParserSpec extends BaseParseSuite:
     )
     val events = yaml.events
     println(events)
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse mapping key with additional space before ':'") {
@@ -324,3 +306,5 @@ class ParserSpec extends BaseParseSuite:
 
     assertEventsEquals(yaml.events, expectedEvents)
   }
+
+end ParserSpec

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/ScalarSpec.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/ScalarSpec.scala
@@ -6,14 +6,11 @@ import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 
 class ScalarSpec extends BaseParseSuite:
 
-  test("should parse value with special charactar':' as scalar") {
+  test("should parse value with special character':' as scalar") {
     val yaml =
       s"""|targetPortal: 10.0.2.15:3260:1221:1221
           |iqn: iqn.2001-04.com.example.storage:kube.sys1.xyz
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -27,16 +24,13 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse plain scalar value") {
     val yaml =
       s"""| mnt\\#dd
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -45,18 +39,15 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
-  test("should parse plain scalar wihth new lines") {
+  test("should parse plain scalar with new lines") {
     val yaml =
       s"""description: new lines
          |  rest.
          |properties: object
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -74,19 +65,16 @@ class ScalarSpec extends BaseParseSuite:
       StreamEnd
     )
 
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
-  test("should parse multine line plain scalar value") {
+  test("should parse multiline plain scalar value") {
     val yaml =
       s"""|description: multiline
           |             plain
           |             scalar
           |type: string
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -100,7 +88,7 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse single quote scalar value with multiline") {
@@ -110,9 +98,6 @@ class ScalarSpec extends BaseParseSuite:
          |               scalar'
          |type: string
          |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -127,16 +112,13 @@ class ScalarSpec extends BaseParseSuite:
       StreamEnd
     )
 
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse value with double quote") {
     val yaml =
       s"""| "/mnt/ iscsipd"
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -145,14 +127,11 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
-  test("should not espace escape special character in double quote scalar") {
+  test("should not escape escape special character in double quote scalar") {
     val yaml = """ "double \n quote" """
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -161,16 +140,13 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse string with single quote") {
     val yaml =
       s"""| '/mnt/ \\iscsipd ''skip'''
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -179,7 +155,7 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse single quote with multiline") {
@@ -187,9 +163,6 @@ class ScalarSpec extends BaseParseSuite:
       s"""|description: 'Quote
           | multiline.'
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -201,7 +174,7 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse string as folded scalar") {
@@ -217,9 +190,6 @@ class ScalarSpec extends BaseParseSuite:
           |    yaml
           |""".stripMargin
 
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
-
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
@@ -233,7 +203,7 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse string as literal scalar") {
@@ -245,9 +215,6 @@ class ScalarSpec extends BaseParseSuite:
           |    CRARG
           |    # We
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -262,16 +229,13 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
-  test("should parse string containing special charactar as scalar with double quote style") {
+  test("should parse string containing special character as scalar with double quote style") {
     val yaml =
       s"""| "{/mnt/ , {}, [] i"
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -280,14 +244,11 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
-  test("should parse double quote scalar esceping \" character") {
+  test("should parse double quote scalar escape \" character") {
     val yaml = s""" "{\\" mnt" """
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -296,7 +257,7 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should skip blank lines at the end in folded value") {
@@ -307,9 +268,6 @@ class ScalarSpec extends BaseParseSuite:
                   |
                   |""".stripMargin
 
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
-
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
@@ -317,7 +275,7 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse new lines for literal style") {
@@ -329,9 +287,6 @@ class ScalarSpec extends BaseParseSuite:
                   |        -----END CERTIFICATE----
                   |kind: v1
                   |        """.stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -348,7 +303,7 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse new lines for literal style with keep final break") {
@@ -362,9 +317,6 @@ class ScalarSpec extends BaseParseSuite:
                   |
                   |kind: v1
                   |        """.stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -381,7 +333,7 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse literal scalar with multiline") {
@@ -392,9 +344,6 @@ class ScalarSpec extends BaseParseSuite:
                   |     set -x
                   | 
                   |     """.stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -415,5 +364,22 @@ class ScalarSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  test("should parse key with additional space before ':'") {
+    val yaml = "key : value"
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      MappingStart(),
+      Scalar("key"),
+      Scalar("value"),
+      MappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+
+    assertEventsEquals(yaml.events, expectedEvents)
   }

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/SequenceSpec.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/internal/load/parse/SequenceSpec.scala
@@ -13,9 +13,6 @@ class SequenceSpec extends BaseParseSuite:
           |    - -c
           |""".stripMargin
 
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
-
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
@@ -29,14 +26,11 @@ class SequenceSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse empty flow sequence") {
     val yaml = "seq: []"
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -49,7 +43,7 @@ class SequenceSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse sequence of sequences") {
@@ -61,9 +55,6 @@ class SequenceSpec extends BaseParseSuite:
           |  - v3
           |  - v4
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -81,7 +72,7 @@ class SequenceSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }
 
   test("should parse sequence of host:port") {
@@ -90,9 +81,6 @@ class SequenceSpec extends BaseParseSuite:
           |portalsSingleQouta: ['10.0.2.16:3260', '10.0.2.17:3260']
           |portalsDoubleQouta: ["10.0.2.16:3260", "10.0.2.17:3260"]
           |""".stripMargin
-
-    val reader = Scanner(yaml)
-    val events = ParserImpl(reader).getEvents()
 
     val expectedEvents = List(
       StreamStart,
@@ -117,5 +105,5 @@ class SequenceSpec extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    assertEventsEquals(events, expectedEvents)
+    assertEventsEquals(yaml.events, expectedEvents)
   }


### PR DESCRIPTION
There were 2 issues with processing following YAML
```yaml
implicit block key : [
  implicit flow key : value,
]
```
1. Additional space after `implicit block key` wasn't handled properly
2. `value` was parsed with comma and closing bracket