### PR TITLE
Add more support for flow collections

### DIFF
--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/Token.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/Token.scala
@@ -20,13 +20,10 @@ enum TokenKind:
   case SequenceValue
   case MappingKey
   case MappingValue
+  case Comma
   case Scalar private (value: String, scalarStyle: ScalarStyle)
 
-  def token(pos: Position): Token = Token(this, pos)
-
 object TokenKind:
-  def scalar: Scalar = Scalar("", ScalarStyle.Plain)
-
   object Scalar:
     def apply(scalar: String, scalarStyle: ScalarStyle) =
       val escapedScalar = ScalarStyle.escapeSpecialCharacter(scalar, scalarStyle)

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/MappingSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/MappingSuite.scala
@@ -221,16 +221,13 @@ class MappingSuite extends BaseParseSuite:
   }
 
   test("empty flow mapping") {
-    val yaml = "emptyDir: {}"
+    val yaml = "{}"
 
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
-      MappingStart(),
-      Scalar("emptyDir"),
       FlowMappingStart(),
       FlowMappingEnd(),
-      MappingEnd(),
       DocumentEnd(),
       StreamEnd
     )
@@ -238,42 +235,116 @@ class MappingSuite extends BaseParseSuite:
   }
 
   test("nested empty flow mapping") {
-    val yaml = "emptyDir: {{{}}}"
+    val yaml = "{{}}"
 
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
-      MappingStart(),
-      Scalar("emptyDir"),
-      FlowMappingStart(),
       FlowMappingStart(),
       FlowMappingStart(),
       FlowMappingEnd(),
-      Scalar(""),
       FlowMappingEnd(),
-      Scalar(""),
-      FlowMappingEnd(),
-      MappingEnd(),
       DocumentEnd(),
       StreamEnd
     )
     assertEventsEquals(yaml.events, expectedEvents)
   }
 
-  test("mapping with flow mapping as value") {
+  test("flow mapping with empty flow seq") {
+    val yaml = "{[]}"
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      FlowMappingStart(),
+      SequenceStart(),
+      SequenceEnd(),
+      FlowMappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  test("mapping with scalar as value") {
     val yaml =
-      s"""doubles: { double1: 1.0 }""".stripMargin
+      s"""{key: value,}""".stripMargin
 
     val events = List(
       StreamStart,
       DocumentStart(),
-      MappingStart(),
-      Scalar("doubles"),
       FlowMappingStart(),
-      Scalar("double1"),
+      Scalar("key"),
+      Scalar("value"),
+      FlowMappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+
+    assertEventsEquals(yaml.events, events)
+  }
+
+  test("mapping with flow mapping as value") {
+    val yaml =
+      s"""|{ 
+          |  {double: 1.0}
+          |}""".stripMargin
+
+    val events = List(
+      StreamStart,
+      DocumentStart(),
+      FlowMappingStart(),
+      FlowMappingStart(),
+      Scalar("double"),
       Scalar("1.0"),
       FlowMappingEnd(),
-      MappingEnd(),
+      FlowMappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+
+    assertEventsEquals(yaml.events, events)
+  }
+
+  test("flow mapping with flow seq as value") {
+    val yaml =
+      s"""|{
+          |  doubles: [v1, v2, ]
+          |}""".stripMargin
+
+    val events = List(
+      StreamStart,
+      DocumentStart(),
+      FlowMappingStart(),
+      Scalar("doubles"),
+      SequenceStart(),
+      Scalar("v1"),
+      Scalar("v2"),
+      SequenceEnd(),
+      FlowMappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+
+    assertEventsEquals(yaml.events, events)
+  }
+
+  test("flow mapping with scalar kv pairs") {
+    val yaml =
+      s"""|{
+          |  k1: v1,
+          |  k2: v2
+          |}""".stripMargin
+
+    val events = List(
+      StreamStart,
+      DocumentStart(),
+      FlowMappingStart(),
+      Scalar("k1"),
+      Scalar("v1"),
+      Scalar("k2"),
+      Scalar("v2"),
+      FlowMappingEnd(),
       DocumentEnd(),
       StreamEnd
     )

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -5,7 +5,7 @@ import org.virtuslab.yaml.internal.load.parse.Event
 import org.virtuslab.yaml.internal.load.parse.Event._
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 
-class SequenceSpec extends BaseParseSuite:
+class SequenceSuite extends BaseParseSuite:
 
   test("basic sequence") {
     val yaml =
@@ -142,16 +142,45 @@ class SequenceSpec extends BaseParseSuite:
   }
 
   test("empty flow sequence") {
-    val yaml = "seq: []"
+    val yaml = "[]"
 
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
-      MappingStart(),
-      Scalar("seq"),
       SequenceStart(),
       SequenceEnd(),
-      MappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  test("empty nested flow sequence") {
+    val yaml = "[[]]"
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      SequenceStart(),
+      SequenceStart(),
+      SequenceEnd(),
+      SequenceEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  test("empty flow sequence with empty flow mapping") {
+    val yaml = "[{}]"
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      SequenceStart(),
+      FlowMappingStart(),
+      FlowMappingEnd(),
+      SequenceEnd(),
       DocumentEnd(),
       StreamEnd
     )
@@ -185,6 +214,31 @@ class SequenceSpec extends BaseParseSuite:
       Scalar("10.0.3.17:3260", ScalarStyle.DoubleQuoted),
       SequenceEnd(),
       MappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  test("flow sequence with single pair") {
+    val yaml = s"""|[
+                   |[ nested ],
+                   |single: pair
+                   |]
+                   |""".stripMargin
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      SequenceStart(),
+      SequenceStart(),
+      Scalar("nested"),
+      SequenceEnd(),
+      MappingStart(),
+      Scalar("single"),
+      Scalar("pair"),
+      MappingEnd(),
+      SequenceEnd(),
       DocumentEnd(),
       StreamEnd
     )

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TokenizerSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TokenizerSuite.scala
@@ -1,33 +1,19 @@
 package org.virtuslab.yaml.tokenizer
 
+import org.virtuslab.yaml.BaseYamlSuite
 import org.virtuslab.yaml.*
 import org.virtuslab.yaml.internal.load.reader.Scanner
-import org.virtuslab.yaml.internal.load.reader.token.TokenKind
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
-import org.virtuslab.yaml.internal.load.parse.Event.MappingStart
+import org.virtuslab.yaml.internal.load.reader.token.TokenKind
+import org.virtuslab.yaml.internal.load.reader.token.TokenKind.*
 
-extension (yaml: String)
-  def tokens: List[TokenKind] =
-    val reader = Scanner(yaml)
-    val tokens = scala.collection.mutable.ArrayDeque[TokenKind]()
-    def loop(): List[TokenKind] =
-      val t = reader.peekToken().kind
-      if t == TokenKind.StreamEnd then tokens.toList
-      else
-        tokens.append(reader.popToken().kind)
-        loop()
-    loop()
-
-  def debugTokens: Unit =
-    println(yaml.tokens)
-
-class TokenizerSuite extends munit.FunSuite:
+class TokenizerSuite extends BaseYamlSuite:
 
   test("scalar") {
     val yaml = "aezakmi"
 
     val tokens = List(
-      TokenKind.Scalar("aezakmi", ScalarStyle.Plain)
+      Scalar("aezakmi", ScalarStyle.Plain)
     )
 
     assertEquals(yaml.tokens, tokens)
@@ -37,12 +23,12 @@ class TokenizerSuite extends munit.FunSuite:
     val yaml = "k : v"
 
     val tokens = List(
-      TokenKind.MappingStart,
-      TokenKind.MappingKey,
-      TokenKind.Scalar("k", ScalarStyle.Plain),
-      TokenKind.MappingValue,
-      TokenKind.Scalar("v", ScalarStyle.Plain),
-      TokenKind.BlockEnd
+      MappingStart,
+      MappingKey,
+      Scalar("k", ScalarStyle.Plain),
+      MappingValue,
+      Scalar("v", ScalarStyle.Plain),
+      BlockEnd
     )
 
     assertEquals(yaml.tokens, tokens)
@@ -54,12 +40,12 @@ class TokenizerSuite extends munit.FunSuite:
                   |""".stripMargin
 
     val tokens = List(
-      TokenKind.SequenceStart,
-      TokenKind.SequenceValue,
-      TokenKind.Scalar("v1", ScalarStyle.Plain),
-      TokenKind.SequenceValue,
-      TokenKind.Scalar("v2", ScalarStyle.Plain),
-      TokenKind.BlockEnd
+      SequenceStart,
+      SequenceValue,
+      Scalar("v1", ScalarStyle.Plain),
+      SequenceValue,
+      Scalar("v2", ScalarStyle.Plain),
+      BlockEnd
     )
 
     assertEquals(yaml.tokens, tokens)
@@ -70,12 +56,61 @@ class TokenizerSuite extends munit.FunSuite:
                   |""".stripMargin
 
     val tokens = List(
-      TokenKind.FlowMappingStart,
-      TokenKind.MappingKey,
-      TokenKind.Scalar("v1", ScalarStyle.Plain),
-      TokenKind.MappingValue,
-      TokenKind.Scalar("v2", ScalarStyle.Plain),
-      TokenKind.FlowMappingEnd
+      FlowMappingStart,
+      MappingKey,
+      Scalar("v1", ScalarStyle.Plain),
+      MappingValue,
+      Scalar("v2", ScalarStyle.Plain),
+      Comma,
+      FlowMappingEnd
+    )
+
+    assertEquals(yaml.tokens, tokens)
+  }
+
+  test("flow mapping implicit values") {
+    val yaml = """|{ 
+                  |k1,
+                  |k2 ,
+                  |k3: ,
+                  |k4:,
+                  |
+                  |}
+                  |""".stripMargin
+
+    val tokens = List(
+      FlowMappingStart,
+      Scalar("k1", ScalarStyle.Plain),
+      Comma,
+      Scalar("k2", ScalarStyle.Plain),
+      Comma,
+      MappingKey,
+      Scalar("k3", ScalarStyle.Plain),
+      MappingValue,
+      Comma,
+      MappingKey,
+      Scalar("k4", ScalarStyle.Plain),
+      MappingValue,
+      Comma,
+      FlowMappingEnd
+    )
+
+    assertEquals(yaml.tokens, tokens)
+  }
+
+  test("flow mapping implicit key") {
+    val yaml = """|{ 
+                  |: v1 
+                  |}
+                  |""".stripMargin
+
+    val tokens = List(
+      FlowMappingStart,
+      MappingKey,
+      Scalar("", ScalarStyle.Plain),
+      MappingValue,
+      Scalar("v1", ScalarStyle.Plain),
+      FlowMappingEnd
     )
 
     assertEquals(yaml.tokens, tokens)
@@ -86,10 +121,72 @@ class TokenizerSuite extends munit.FunSuite:
                   |""".stripMargin
 
     val tokens = List(
-      TokenKind.FlowSequenceStart,
-      TokenKind.Scalar("v1", ScalarStyle.Plain),
-      TokenKind.Scalar("v2", ScalarStyle.Plain),
-      TokenKind.FlowSequenceEnd
+      FlowSequenceStart,
+      Scalar("v1", ScalarStyle.Plain),
+      Comma,
+      Scalar("v2", ScalarStyle.Plain),
+      Comma,
+      FlowSequenceEnd
+    )
+
+    assertEquals(yaml.tokens, tokens)
+  }
+
+  test("flow sequence mapping") {
+    val yaml = """|[ k1: v2, ]
+                  |""".stripMargin
+
+    val tokens = List(
+      FlowSequenceStart,
+      MappingKey,
+      Scalar("k1", ScalarStyle.Plain),
+      MappingValue,
+      Scalar("v2", ScalarStyle.Plain),
+      Comma,
+      FlowSequenceEnd
+    )
+
+    assertEquals(yaml.tokens, tokens)
+  }
+
+  test("flow sequence mapping") {
+    val yaml = s"""|[
+                   |[ nested ],
+                   |single: pair
+                   |]
+                   |""".stripMargin
+
+    val tokens = List(
+      FlowSequenceStart,
+      FlowSequenceStart,
+      Scalar("nested", ScalarStyle.Plain),
+      FlowSequenceEnd,
+      Comma,
+      MappingKey,
+      Scalar("single", ScalarStyle.Plain),
+      MappingValue,
+      Scalar("pair", ScalarStyle.Plain),
+      FlowSequenceEnd
+    )
+
+    assertEquals(yaml.tokens, tokens)
+  }
+
+  test("flow sequence mapping nested") {
+    val yaml = """|[ k1: k2: plain
+                  |    text ]
+                  |""".stripMargin
+
+    val tokens = List(
+      FlowSequenceStart,
+      MappingKey,
+      Scalar("k1", ScalarStyle.Plain),
+      MappingValue,
+      MappingKey,
+      Scalar("k2", ScalarStyle.Plain),
+      MappingValue,
+      Scalar("plain text", ScalarStyle.Plain),
+      FlowSequenceEnd
     )
 
     assertEquals(yaml.tokens, tokens)


### PR DESCRIPTION
Generate comma tokens, they are used to separated flow entries in flow collections. Flow collections are just an enhanced JSON syntax so most of the constructs are pretty straightforward. 

 Moreover, in sequence you can use single mapping shorthand syntax - `[key: value]` instead of `[{key: pair}]