### PR TITLE
Fix parsing double quoted scalar

### DIFF
--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
@@ -99,12 +99,14 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
           in.skipN(2)
           sb.append("\"")
           readScalar()
-        case Some('"') | None =>
+        case Some('"') =>
           in.skipCharacter()
           sb.result()
         case Some(char) =>
           sb.append(in.read())
           readScalar()
+        case None =>
+          sb.result()
 
     val pos = in.pos
     in.skipCharacter() // skip double quote


### PR DESCRIPTION
Previously, for an invalid YAML like `"aezakmi`, which was missing a closing quote, the exception was thrown.