### PR TITLE
Fix parsing implicit block key

### DIFF
--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
@@ -15,6 +15,7 @@ trait Reader:
   def isNewline: Boolean
   def skipCharacter(): Unit
   def skipN(n: Int): Unit
+  def skipWhitespaces(): Unit
 
   def line: Int
   def column: Int
@@ -66,6 +67,10 @@ private[yaml] class StringReader(in: String) extends Reader:
     loop(n)
 
   override def skipCharacter(): Unit = skipAndMantainPosition()
+
+  def skipWhitespaces(): Unit =
+    while (isWhitespace)
+      skipCharacter()
 
   override def read(): Char =
     skipCharacter()

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
@@ -275,6 +275,7 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
       case Some('|')  => parseLiteral()
       case _          => parseScalarValue()
 
+    in.skipWhitespaces()
     val peeked2 = in.peek()
     peeked2 match
       case Some(':') =>

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/MappingSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/MappingSuite.scala
@@ -351,3 +351,28 @@ class MappingSuite extends BaseParseSuite:
 
     assertEventsEquals(yaml.events, events)
   }
+
+  test("implicit block key in sequence flow") {
+    val yaml =
+      s""""implicit block key" : [
+           |  "implicit flow key" : value,
+           | ]""".stripMargin
+
+    val events = List(
+      StreamStart,
+      DocumentStart(),
+      MappingStart(),
+      Scalar("implicit block key", style = ScalarStyle.DoubleQuoted),
+      SequenceStart(),
+      MappingStart(),
+      Scalar("implicit flow key", style = ScalarStyle.DoubleQuoted),
+      Scalar("value"),
+      MappingEnd(),
+      SequenceEnd(),
+      MappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+
+    assertEventsEquals(yaml.events, events)
+  }


### PR DESCRIPTION
Identifier of key `:` doesn't have to appear immediately after the scaler. May be separated by whitespace.