### PR TITLE
Parsing anchors & aliases

### DIFF
--- a/tests/test-suite/jvm/src/it/scala/org/virtuslab/yaml/YamlRunnerSpec.scala
+++ b/tests/test-suite/jvm/src/it/scala/org/virtuslab/yaml/YamlRunnerSpec.scala
@@ -9,7 +9,7 @@ abstract class YamlRunnerSpec extends munit.FunSuite {
 
   val verbose                       = false
   val predicate: os.Path => Boolean = _ => true
-
+  
   val yamlDirPath              = getClass.getResource(resourcePath)
   val yamlDir                  = new File(yamlDirPath.getPath)
   val yamlPaths: List[os.Path] = yamlDir.listFiles().map(os.Path(_)).filter(predicate).toList
@@ -22,13 +22,12 @@ abstract class YamlRunnerSpec extends munit.FunSuite {
           val testRunner = createTestRunner(path)
           if (verbose) {
             println(s"Running $path")
-            println(testRunner.inYaml)
           }
           val runnerResult = testRunner.run()
           runnerResult match
             case RunnerResult.Success(_) => loop(tail, failsPath)
             case RunnerResult.InvalidEvents(obtained, expected) =>
-              println(s"Failed test - $path")
+              println(s"Events differ - $path")
               if (verbose) {
                 println(s"Obtained:\n$obtained")
                 println(s"Expected:\n$expected")

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/dump/present/PresenterImpl.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/dump/present/PresenterImpl.scala
@@ -27,7 +27,7 @@ object PresenterImpl extends Presenter:
               insertSequencePadding()
               pushAndIncreaseIndent(Event.SequenceStart())
               parseSequence(tail)
-            case Event.Scalar(value, _, _) =>
+            case Event.Scalar(value, _, _, _) =>
               insertSequencePadding()
               // todo escape string using doublequotes
               sb.append(value)
@@ -44,7 +44,7 @@ object PresenterImpl extends Presenter:
         case Event.MappingEnd(_) :: tail =>
           popAndDecreaseIndent()
           tail
-        case Event.Scalar(value, _, _) :: tail =>
+        case Event.Scalar(value, _, _, _) :: tail =>
           appendKey(value)
           val rest = parseNode(tail)
           parseMapping(rest)

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
@@ -35,7 +35,9 @@ object ComposerImpl extends Composer:
         case _: Event.SequenceStart                            => composeSequenceNode(tail)
         case _: Event.MappingStart | _: Event.FlowMappingStart => composeMappingNode(tail)
         case s: Event.Scalar                                   => composeScalarNode(s, tail)
-        case event => Left(ComposerError(s"Unexpected event $event"))
+        // todo #88
+        case _: Event.Alias => Left(ComposerError(s"Aliases aren't currently supported"))
+        case event          => Left(ComposerError(s"Unexpected event $event"))
     case Nil =>
       Left(ComposerError("No events available"))
 

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
@@ -37,7 +37,7 @@ object ComposerImpl extends Composer:
         case s: Event.Scalar                                   => composeScalarNode(s, tail)
         // todo #88
         case _: Event.Alias => Left(ComposerError(s"Aliases aren't currently supported"))
-        case event          => Left(ComposerError(s"Unexpected event $event"))
+        case event          => Left(ComposerError(s"Expected Node, but found: $event"))
     case Nil =>
       Left(ComposerError("No events available"))
 

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
@@ -3,6 +3,7 @@ package org.virtuslab.yaml.internal.load.parse
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 import org.virtuslab.yaml.Position
 import org.virtuslab.yaml.internal.load.parse.Event.StreamStart
+import org.virtuslab.yaml.internal.load.parse.Event.Node
 
 /** 
  * 
@@ -29,18 +30,23 @@ object Event:
       extends Document
 
   sealed trait Node extends Event
+
+
+  final case class Alias(id: String, pos: Option[Position] = None) extends Event
+
   final case class Scalar(
       value: String,
       style: ScalarStyle = ScalarStyle.Plain,
-      pos: Option[Position] = None
+      pos: Option[Position] = None,
+      anchor: Option[String] = None
   ) extends Node
 
   sealed trait Sequence                                  extends Node
-  case class SequenceStart(pos: Option[Position] = None) extends Sequence
+  case class SequenceStart(pos: Option[Position] = None, anchor: Option[String] = None) extends Sequence
   case class SequenceEnd(pos: Option[Position] = None)   extends Sequence
 
   sealed trait Mapping                                      extends Node
-  case class MappingStart(pos: Option[Position] = None)     extends Mapping
+  case class MappingStart(pos: Option[Position] = None, anchor: Option[String] = None)     extends Mapping
   case class MappingEnd(pos: Option[Position] = None)       extends Mapping
-  case class FlowMappingStart(pos: Option[Position] = None) extends Mapping
+  case class FlowMappingStart(pos: Option[Position] = None, anchor: Option[String] = None) extends Mapping
   case class FlowMappingEnd(pos: Option[Position] = None)   extends Mapping

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
@@ -31,7 +31,6 @@ object Event:
 
   sealed trait Node extends Event
 
-
   final case class Alias(id: String, pos: Option[Position] = None) extends Event
 
   final case class Scalar(
@@ -41,12 +40,15 @@ object Event:
       anchor: Option[String] = None
   ) extends Node
 
-  sealed trait Sequence                                  extends Node
-  case class SequenceStart(pos: Option[Position] = None, anchor: Option[String] = None) extends Sequence
-  case class SequenceEnd(pos: Option[Position] = None)   extends Sequence
+  sealed trait Sequence extends Node
+  case class SequenceStart(pos: Option[Position] = None, anchor: Option[String] = None)
+      extends Sequence
+  case class SequenceEnd(pos: Option[Position] = None) extends Sequence
 
-  sealed trait Mapping                                      extends Node
-  case class MappingStart(pos: Option[Position] = None, anchor: Option[String] = None)     extends Mapping
-  case class MappingEnd(pos: Option[Position] = None)       extends Mapping
-  case class FlowMappingStart(pos: Option[Position] = None, anchor: Option[String] = None) extends Mapping
-  case class FlowMappingEnd(pos: Option[Position] = None)   extends Mapping
+  sealed trait Mapping extends Node
+  case class MappingStart(pos: Option[Position] = None, anchor: Option[String] = None)
+      extends Mapping
+  case class MappingEnd(pos: Option[Position] = None) extends Mapping
+  case class FlowMappingStart(pos: Option[Position] = None, anchor: Option[String] = None)
+      extends Mapping
+  case class FlowMappingEnd(pos: Option[Position] = None) extends Mapping

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
@@ -105,7 +105,6 @@ final class ParserImpl private (in: Tokenizer) extends Parser:
     def loop(events: mutable.ArrayDeque[Event]): Either[YamlError, List[Event]] = {
       getNextEvent() match
         case Right(event) =>
-          println(event)
           if event != Event.StreamEnd then loop(events.append(event))
           else Right(events.append(event).toList)
         case Left(err) => Left(err)
@@ -336,9 +335,9 @@ final class ParserImpl private (in: Tokenizer) extends Parser:
         case _ =>
           Left(ParseError.from(TokenKind.Scalar.toString, token))
 
-    inline def parseFlowNode() = parseNode(couldParseBlockColl = false)
+    inline def parseFlowNode() = parseNode(couldParseBlockCollection = false)
 
-    def parseNode(couldParseBlockColl: Boolean = true): Either[YamlError, Event] =
+    def parseNode(couldParseBlockCollection: Boolean = true): Either[YamlError, Event] =
       val (anchor, nextToken) = parseNodeAttributes()
 
       nextToken.kind match
@@ -347,11 +346,11 @@ final class ParserImpl private (in: Tokenizer) extends Parser:
           else
             in.popToken()
             Right(Event.Alias(alias))
-        case TokenKind.MappingStart if couldParseBlockColl =>
+        case TokenKind.MappingStart if couldParseBlockCollection =>
           in.popToken()
           productions.prependAll(ParseMappingEntry :: ParseMappingEnd :: Nil)
           Right(Event.MappingStart(Some(pos), anchor))
-        case TokenKind.SequenceStart if couldParseBlockColl =>
+        case TokenKind.SequenceStart if couldParseBlockCollection =>
           parseSequenceStart()
         case TokenKind.FlowMappingStart =>
           in.popToken()

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
@@ -254,7 +254,9 @@ final class ParserImpl private (in: Tokenizer) extends Parser:
         productions.prependAll(ParseFlowNode :: Nil)
         getNextEventImpl()
       case TokenKind.Scalar(_, _) =>
-        productions.prependAll(ParseFlowNode :: ParseFlowMappingComma :: ParseFlowMappingEntry :: Nil)
+        productions.prependAll(
+          ParseFlowNode :: ParseFlowMappingComma :: ParseFlowMappingEntry :: Nil
+        )
         parseFlowNode()
       case _ =>
         getNextEventImpl()
@@ -341,8 +343,7 @@ final class ParserImpl private (in: Tokenizer) extends Parser:
 
       nextToken.kind match
         case TokenKind.Alias(alias) =>
-          if anchor.isDefined then
-            Left(ParseError.from("Alias cannot have an anchor", nextToken))
+          if anchor.isDefined then Left(ParseError.from("Alias cannot have an anchor", nextToken))
           else
             in.popToken()
             Right(Event.Alias(alias))

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/Token.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/Token.scala
@@ -10,6 +10,8 @@ enum TokenKind:
   case StreamEnd
   case DocumentStart
   case DocumentEnd
+  case Anchor(value: String)
+  case Alias(value: String)
   case MappingStart
   case SequenceStart
   case BlockEnd

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/decoder/PrimitiveDecoderSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/decoder/PrimitiveDecoderSuite.scala
@@ -115,7 +115,7 @@ class PrimitiveDecoderSuite extends munit.FunSuite:
     assertEquals(mappingYaml.as[SequenceTypes], Right(expectedMapping))
   }
 
-  test("mapping") {
+  test("mapping-2") {
     case class SequenceTypes(doubles: Map[String, Double], floats: Map[String, List[Float]])
         derives YamlCodec
 

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/AnchorSpec.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/AnchorSpec.scala
@@ -1,0 +1,167 @@
+package org.virtuslab.yaml.parser
+
+import org.virtuslab.yaml.internal.load.parse.Event._
+import org.virtuslab.yaml.internal.load.reader.Scanner
+
+class AnchorSpec extends BaseParseSuite:
+
+  test("in mapping") {
+    val yaml =
+      s"""|First occurrence: &anchor Foo
+          |Second occurrence: *anchor
+          |Override anchor: &anchor Bar
+          |Reuse anchor: *anchor
+          |""".stripMargin
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      MappingStart(),
+      Scalar("First occurrence"),
+      Scalar("Foo", anchor = Some("anchor")),
+      Scalar("Second occurrence"),
+      Alias("anchor"),
+      Scalar("Override anchor"),
+      Scalar("Bar", anchor = Some("anchor")),
+      Scalar("Reuse anchor"),
+      Alias("anchor"),
+      MappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    yaml.debugTokens
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  // need improvement in tokenizer
+  test("in mapping but with keys aliased".ignore) {
+    val yaml =
+      s"""|&a a: &b b
+          |*b : *a
+          |""".stripMargin
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      MappingStart(),
+      Scalar("a", anchor = Some("a")),
+      Scalar("b", anchor = Some("b")),
+      Alias("a"),
+      Alias("b"),
+      MappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    yaml.debugTokens
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  test("in sequence") {
+    val yaml =
+      s"""|- &a a
+          |- &b b
+          |- *a
+          |- *b
+          |""".stripMargin
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      SequenceStart(),
+      Scalar("a", anchor = Some("a")),
+      Scalar("b", anchor = Some("b")),
+      Alias("a"),
+      Alias("b"),
+      SequenceEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  test("as empty values") {
+    val yaml = s"""|---
+                   |a: &anchor
+                   |b: *anchor
+                   |""".stripMargin
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(explicit = true),
+      MappingStart(),
+      Scalar("a"),
+      Scalar("", anchor = Some("anchor")),
+      Scalar("b"),
+      Alias("anchor"),
+      MappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  test("anchor in flow collections".ignore) {
+    val yaml =
+      s"""|{
+          |  a : &b b,
+          |  seq: [a, *b]
+          |}""".stripMargin
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      FlowMappingStart(),
+      Scalar("a", anchor = Some("a")),
+      Scalar("b", anchor = Some("b")),
+      Scalar("seq"),
+      SequenceStart(),
+      Alias("a"),
+      Alias("b"),
+      SequenceEnd(),
+      FlowMappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    yaml.debugTokens
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+
+  test("anchor & alias".ignore) {
+    val yaml =
+      s"""|---
+          |a: &anchor
+          |b: *anchor
+          |""".stripMargin
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+
+      DocumentEnd(),
+      StreamEnd
+    )
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
+  test("anchor & alias".ignore) {
+    val yaml =
+      s"""|---
+          |hr:
+          |  - Mark McGwire
+          |  # Following node labeled SS
+          |  - &SS Sammy Sosa
+          |rbi:
+          |  - *SS # Subsequent occurrence
+          |  - Ken Griffey
+          |""".stripMargin
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+
+      DocumentEnd(),
+      StreamEnd
+    )
+    assertEventsEquals(yaml.events, expectedEvents)
+  }

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/AnchorSpec.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/AnchorSpec.scala
@@ -126,7 +126,6 @@ class AnchorSpec extends BaseParseSuite:
     assertEventsEquals(yaml.events, expectedEvents)
   }
 
-
   test("anchor & alias".ignore) {
     val yaml =
       s"""|---
@@ -137,7 +136,6 @@ class AnchorSpec extends BaseParseSuite:
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
-
       DocumentEnd(),
       StreamEnd
     )
@@ -159,7 +157,6 @@ class AnchorSpec extends BaseParseSuite:
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
-
       DocumentEnd(),
       StreamEnd
     )

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/BaseParseSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/BaseParseSuite.scala
@@ -31,6 +31,7 @@ trait BaseParseSuite extends BaseYamlSuite:
           case e: Event.FlowMappingStart => e.copy(pos = None)
           case e: Event.FlowMappingEnd   => e.copy(pos = None)
           case e: Event.Scalar           => e.copy(pos = None)
+          case e: Event.Alias           => e.copy(pos = None)
       }
     )
     val expected = Right(expectedEvents)

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/BaseParseSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/BaseParseSuite.scala
@@ -31,7 +31,7 @@ trait BaseParseSuite extends BaseYamlSuite:
           case e: Event.FlowMappingStart => e.copy(pos = None)
           case e: Event.FlowMappingEnd   => e.copy(pos = None)
           case e: Event.Scalar           => e.copy(pos = None)
-          case e: Event.Alias           => e.copy(pos = None)
+          case e: Event.Alias            => e.copy(pos = None)
       }
     )
     val expected = Right(expectedEvents)

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/MappingSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/MappingSuite.scala
@@ -182,6 +182,28 @@ class MappingSuite extends BaseParseSuite:
     assertEventsEquals(yaml.events, expectedEvents)
   }
 
+  test("flow mapping") {
+    val yaml = s"""doubles: { double1: 1.0, double2: 2.0 }""".stripMargin
+
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      MappingStart(),
+      Scalar("doubles"),
+      FlowMappingStart(),
+      Scalar("double1"),
+      Scalar("1.0"),
+      Scalar("double2"),
+      Scalar("2.0"),
+      FlowMappingEnd(),
+      MappingEnd(),
+      DocumentEnd(),
+      StreamEnd
+    )
+    
+    assertEventsEquals(yaml.events, expectedEvents)
+  }
+
   test("mapping with braces in value") {
     val yaml = "name: etcd-{{cell}}"
 

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/MappingSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/MappingSuite.scala
@@ -200,7 +200,7 @@ class MappingSuite extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-    
+
     assertEventsEquals(yaml.events, expectedEvents)
   }
 

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -23,7 +23,6 @@ class SequenceSuite extends BaseParseSuite:
       DocumentEnd(),
       StreamEnd
     )
-
     assertEventsEquals(yaml.events, expectedEvents)
   }
 

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TokenizerSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TokenizerSuite.scala
@@ -195,6 +195,8 @@ class TokenizerSuite extends BaseYamlSuite:
   test("anchor & alias in mapping") {
     val yaml = """|First occurrence: &anchor Value
                   |Second occurrence: *anchor
+                  |Override anchor: &anchor Bar
+                  |Reuse anchor: *anchor
                   |""".stripMargin
 
     val tokens = List(
@@ -206,6 +208,15 @@ class TokenizerSuite extends BaseYamlSuite:
       Scalar("Value", ScalarStyle.Plain),
       MappingKey,
       Scalar("Second occurrence", ScalarStyle.Plain),
+      MappingValue,
+      Alias("anchor"),
+      MappingKey,
+      Scalar("Override anchor", ScalarStyle.Plain),
+      MappingValue,
+      Anchor("anchor"),
+      Scalar("Bar", ScalarStyle.Plain),
+      MappingKey,
+      Scalar("Reuse anchor", ScalarStyle.Plain),
       MappingValue,
       Alias("anchor"),
       BlockEnd

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TokenizerSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TokenizerSuite.scala
@@ -191,3 +191,64 @@ class TokenizerSuite extends BaseYamlSuite:
 
     assertEquals(yaml.tokens, tokens)
   }
+
+  test("anchor & alias in mapping") {
+    val yaml = """|First occurrence: &anchor Value
+                  |Second occurrence: *anchor
+                  |""".stripMargin
+
+    val tokens = List(
+      MappingStart,
+      MappingKey,
+      Scalar("First occurrence", ScalarStyle.Plain),
+      MappingValue,
+      Anchor("anchor"),
+      Scalar("Value", ScalarStyle.Plain),
+      MappingKey,
+      Scalar("Second occurrence", ScalarStyle.Plain),
+      MappingValue,
+      Alias("anchor"),
+      BlockEnd
+    )
+
+    assertEquals(yaml.tokens, tokens)
+  }
+
+  test("anchor & alias in sequence") {
+    val yaml = """|---
+                  |hr:
+                  |  - Mark McGwire
+                  |  # Following node labeled SS
+                  |  - &SS Sammy Sosa
+                  |rbi:
+                  |  - *SS # Subsequent occurrence
+                  |  - Ken Griffey
+                  |""".stripMargin
+
+    val tokens = List(
+      DocumentStart,
+      MappingStart,
+      MappingKey,
+      Scalar("hr", ScalarStyle.Plain),
+      MappingValue,
+      SequenceStart,
+      SequenceValue,
+      Scalar("Mark McGwire", ScalarStyle.Plain),
+      SequenceValue,
+      Anchor("SS"),
+      Scalar("Sammy Sosa", ScalarStyle.Plain),
+      BlockEnd,
+      MappingKey,
+      Scalar("rbi", ScalarStyle.Plain),
+      MappingValue,
+      SequenceStart,
+      SequenceValue,
+      Alias("SS"),
+      SequenceValue,
+      Scalar("Ken Griffey", ScalarStyle.Plain),
+      BlockEnd,
+      BlockEnd
+    )
+
+    assertEquals(yaml.tokens, tokens)
+  }


### PR DESCRIPTION
We still cannot parse anchor when a node is mapping key at the same time (require tokenizer changes from #87). Otherwise, it should just work. 

Follow-up: Handle anchors & aliases when composing nodes https://github.com/VirtusLab/scala-yaml/issues/88