### PR TITLE
Add tags to nodes

### DIFF
--- a/tests/test-suite/jvm/src/main/scala/org/virtuslab/yaml/TestRunner.scala
+++ b/tests/test-suite/jvm/src/main/scala/org/virtuslab/yaml/TestRunner.scala
@@ -6,13 +6,12 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
-import org.virtuslab.yaml
+import org.virtuslab.yaml.Tag
 import org.virtuslab.yaml.internal.load.parse.Anchor
 import org.virtuslab.yaml.internal.load.parse.EventKind
 import org.virtuslab.yaml.internal.load.parse.EventKind.*
 import org.virtuslab.yaml.internal.load.parse.NodeEventMetadata
 import org.virtuslab.yaml.internal.load.parse.ParserImpl
-import org.virtuslab.yaml.internal.load.parse.Tag
 import org.virtuslab.yaml.internal.load.reader.Scanner
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/LoadSettings.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/LoadSettings.scala
@@ -1,0 +1,5 @@
+package org.virtuslab.yaml
+
+case class LoadSettings(constructors: Map[Tag, YamlDecoder[Any]])
+object LoadSettings:
+  val empty = LoadSettings(Map.empty)

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/LoadSettings.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/LoadSettings.scala
@@ -1,5 +1,5 @@
 package org.virtuslab.yaml
 
-case class LoadSettings(constructors: Map[Tag, YamlDecoder[Any]])
+case class LoadSettings(constructors: Map[Tag, YamlDecoder[?]])
 object LoadSettings:
   val empty = LoadSettings(Map.empty)

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/Node.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/Node.scala
@@ -1,46 +1,76 @@
 package org.virtuslab.yaml
 
 import org.virtuslab.yaml.Range
+import org.virtuslab.yaml.Tag
 import org.virtuslab.yaml.syntax.YamlPrimitive
 
 /**
   * ADT that corresponds to the YAML representation graph nodes https://yaml.org/spec/1.2/spec.html#id2764044
 */
 sealed trait Node:
-  def pos: Option[Range]
+  private[yaml] def pos: Option[Range]
+  def tag: Tag
 
 object Node:
-  final case class ScalarNode(value: String, pos: Option[Range] = None) extends Node
+  final case class ScalarNode private[yaml] (value: String, tag: Tag, pos: Option[Range] = None)
+      extends Node
 
   object ScalarNode:
-    def apply(value: String): ScalarNode = new ScalarNode(value)
+    def apply(value: String): ScalarNode = new ScalarNode(value, Tag.resolveTag(value))
+    def unapply(node: ScalarNode): Option[(String, Tag)] = Some((node.value, node.tag))
+  end ScalarNode
 
-  final case class SequenceNode(nodes: Seq[Node], pos: Option[Range] = None) extends Node
-  object SequenceNode:
-    def apply(nodes: Node*): SequenceNode = new SequenceNode(nodes, None)
-    def apply(first: YamlPrimitive, rest: YamlPrimitive*): SequenceNode =
-      val nodes: List[YamlPrimitive] = (first :: rest.toList)
-      new SequenceNode(nodes.map(_.node), None)
-
-  final case class MappingNode(
-      mappings: Seq[KeyValueNode],
+  final case class SequenceNode private[yaml] (
+      nodes: Seq[Node],
+      tag: Tag,
       pos: Option[Range] = None
   ) extends Node
+  object SequenceNode:
+    def apply(nodes: Node*): SequenceNode = new SequenceNode(nodes, Tag.seq, None)
+    def apply(first: YamlPrimitive, rest: YamlPrimitive*): SequenceNode =
+      val nodes: List[YamlPrimitive] = (first :: rest.toList)
+      new SequenceNode(nodes.map(_.node), Tag.seq, None)
+    def unapply(node: SequenceNode): Option[(Seq[Node], Tag)] = Some((node.nodes, node.tag))
+  end SequenceNode
 
+  final case class MappingNode private[yaml] (
+      mappings: Map[Node, Node],
+      tag: Tag,
+      pos: Option[Range] = None
+  ) extends Node
   object MappingNode:
-    def apply(nodes: KeyValueNode*): MappingNode = MappingNode(nodes, None)
+    def apply(mappings: Map[Node, Node]): MappingNode = MappingNode(mappings, Tag.map, None)
+    def apply(mappings: (Node, Node)*): MappingNode   = MappingNode(mappings.toMap, Tag.map, None)
     def apply(
         first: (YamlPrimitive, YamlPrimitive),
         rest: (YamlPrimitive, YamlPrimitive)*
     ): MappingNode =
-      val nodes = (first :: rest.toList)
-      val kvn   = nodes.map((k, v) => KeyValueNode(k.node, v.node))
-      new MappingNode(kvn, None)
-
-  final case class KeyValueNode(
-      key: Node,
-      value: Node,
-      pos: Option[Range] = None
-  ) extends Node
-
+      val primitives = (first :: rest.toList)
+      val mappings   = primitives.map((k, v) => (k.node -> v.node)).toMap
+      new MappingNode(mappings, Tag.map, None)
+    def unapply(node: MappingNode): Option[(Map[Node, Node], Tag)] = Some((node.mappings, node.tag))
+  end MappingNode
 end Node
+
+private object TagResolver {
+  val nullPattern   = "null|Null|NULL|~".r
+  val boolean       = "true|True|TRUE|false|False|FALSE".r
+  val int10         = "[-+]?[0-9]+".r
+  val int8          = "0o[0-7]+".r
+  val int16         = "0x[0-9a-fA-F]+".r
+  val float         = "[-+]?(\\.[0-9]+|[0-9]+(\\.[0-9]*)?)([eE][-+]?[0-9]+)?".r
+  val minusInfinity = "-(\\.inf|\\.Inf|\\.INF)".r
+  val plusInfinity  = "\\+?(\\.inf|\\.Inf|\\.INF)".r
+
+  def resolveTag(value: String) =
+    value match
+      case null              => 1
+      case nullPattern(_*)   => 2
+      case boolean(_*)       => 3
+      case int10(_*)         => 4
+      case int8(_*)          => 5
+      case int16(_*)         => 6
+      case float(_*)         => 7
+      case minusInfinity(_*) => 8
+      case plusInfinity(_*)  => 9
+}

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/Node.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/Node.scala
@@ -10,6 +10,10 @@ import org.virtuslab.yaml.syntax.YamlPrimitive
 sealed trait Node:
   private[yaml] def pos: Option[Range]
   def tag: Tag
+  def as[T](using
+      c: YamlDecoder[T],
+      settings: LoadSettings = LoadSettings.empty
+  ): Either[YamlError, T] = c.construct(this)
 
 object Node:
   final case class ScalarNode private[yaml] (value: String, tag: Tag, pos: Option[Range] = None)
@@ -51,26 +55,3 @@ object Node:
     def unapply(node: MappingNode): Option[(Map[Node, Node], Tag)] = Some((node.mappings, node.tag))
   end MappingNode
 end Node
-
-private object TagResolver {
-  val nullPattern   = "null|Null|NULL|~".r
-  val boolean       = "true|True|TRUE|false|False|FALSE".r
-  val int10         = "[-+]?[0-9]+".r
-  val int8          = "0o[0-7]+".r
-  val int16         = "0x[0-9a-fA-F]+".r
-  val float         = "[-+]?(\\.[0-9]+|[0-9]+(\\.[0-9]*)?)([eE][-+]?[0-9]+)?".r
-  val minusInfinity = "-(\\.inf|\\.Inf|\\.INF)".r
-  val plusInfinity  = "\\+?(\\.inf|\\.Inf|\\.INF)".r
-
-  def resolveTag(value: String) =
-    value match
-      case null              => 1
-      case nullPattern(_*)   => 2
-      case boolean(_*)       => 3
-      case int10(_*)         => 4
-      case int8(_*)          => 5
-      case int16(_*)         => 6
-      case float(_*)         => 7
-      case minusInfinity(_*) => 8
-      case plusInfinity(_*)  => 9
-}

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/Node.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/Node.scala
@@ -13,7 +13,8 @@ sealed trait Node:
   def as[T](using
       c: YamlDecoder[T],
       settings: LoadSettings = LoadSettings.empty
-  ): Either[YamlError, T] = c.construct(this)
+  ): Either[YamlError, T] =
+    c.construct(this)
 
 object Node:
   final case class ScalarNode private[yaml] (value: String, tag: Tag, pos: Option[Range] = None)

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/Tag.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/Tag.scala
@@ -1,0 +1,42 @@
+package org.virtuslab.yaml
+
+import scala.reflect.ClassTag
+
+final case class Tag(value: String)
+
+object Tag:
+  def apply[T](implicit classTag: ClassTag[T]): Tag = Tag(s"!${classTag.runtimeClass.getName}")
+
+  private val default = "tag:yaml.org,2002:"
+  val nullTag: Tag    = Tag(s"${default}null")
+  val boolean: Tag    = Tag(s"${default}bool")
+  val int: Tag        = Tag(s"${default}int")
+  val float: Tag      = Tag(s"${default}float")
+  val str: Tag        = Tag(s"${default}str")
+  val seq: Tag        = Tag(s"${default}seq")
+  val map: Tag        = Tag(s"${default}map")
+
+  private val nullPattern    = "null|Null|NULL|~".r
+  private val booleanPattern = "true|True|TRUE|false|False|FALSE".r
+  private val int10Pattern   = "[-+]?[0-9]+".r
+  private val int8Pattern    = "0o[0-7]+".r
+  private val int16Pattern   = "0x[0-9a-fA-F]+".r
+  private val floatPattern   = "[-+]?(\\.[0-9]+|[0-9]+(\\.[0-9]*)?)([eE][-+]?[0-9]+)?".r
+  private val minusInfinity  = "-(\\.inf|\\.Inf|\\.INF)".r
+  private val plusInfinity   = "\\+?(\\.inf|\\.Inf|\\.INF)".r
+
+  def resolveTag(value: String): Tag = {
+    value match {
+      case null               => nullTag
+      case nullPattern(_*)    => nullTag
+      case booleanPattern(_*) => boolean
+      case int10Pattern(_*)   => int
+      case int8Pattern(_*)    => int
+      case int16Pattern(_*)   => int
+      case floatPattern(_*)   => float
+      case minusInfinity(_*)  => float
+      case plusInfinity(_*)   => float
+      case _                  => str
+    }
+  }
+end Tag

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/Tag.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/Tag.scala
@@ -16,6 +16,8 @@ object Tag:
   val seq: Tag        = Tag(s"${default}seq")
   val map: Tag        = Tag(s"${default}map")
 
+  val primitives = Set(nullTag, boolean, int, float, str)
+
   private val nullPattern    = "null|Null|NULL|~".r
   private val booleanPattern = "true|True|TRUE|false|False|FALSE".r
   private val int10Pattern   = "[-+]?[0-9]+".r

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/Tag.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/Tag.scala
@@ -2,21 +2,28 @@ package org.virtuslab.yaml
 
 import scala.reflect.ClassTag
 
-final case class Tag(value: String)
+sealed trait Tag:
+  def value: String
+
+final case class CoreSchemaTag(value: String) extends Tag
+final case class CustomTag(value: String)     extends Tag
 
 object Tag:
-  def apply[T](implicit classTag: ClassTag[T]): Tag = Tag(s"!${classTag.runtimeClass.getName}")
+  def apply[T](implicit classTag: ClassTag[T]): Tag = CustomTag(
+    s"!${classTag.runtimeClass.getName}"
+  )
 
   private val default = "tag:yaml.org,2002:"
-  val nullTag: Tag    = Tag(s"${default}null")
-  val boolean: Tag    = Tag(s"${default}bool")
-  val int: Tag        = Tag(s"${default}int")
-  val float: Tag      = Tag(s"${default}float")
-  val str: Tag        = Tag(s"${default}str")
-  val seq: Tag        = Tag(s"${default}seq")
-  val map: Tag        = Tag(s"${default}map")
+  val nullTag: Tag    = CoreSchemaTag(s"${default}null")
+  val boolean: Tag    = CoreSchemaTag(s"${default}bool")
+  val int: Tag        = CoreSchemaTag(s"${default}int")
+  val float: Tag      = CoreSchemaTag(s"${default}float")
+  val str: Tag        = CoreSchemaTag(s"${default}str")
+  val seq: Tag        = CoreSchemaTag(s"${default}seq")
+  val map: Tag        = CoreSchemaTag(s"${default}map")
 
-  val primitives = Set(nullTag, boolean, int, float, str)
+  val corePrimitives   = Set(nullTag, boolean, int, float, str)
+  val coreSchemaValues = (corePrimitives ++ Set(seq, map)).map(_.value)
 
   private val nullPattern    = "null|Null|NULL|~".r
   private val booleanPattern = "true|True|TRUE|false|False|FALSE".r

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/Yaml.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/Yaml.scala
@@ -13,8 +13,6 @@ inline def deriveYamlEncoder[T](using m: Mirror.Of[T]): YamlEncoder[T] = YamlEnc
 inline def deriveYamlDecoder[T](using m: Mirror.Of[T]): YamlDecoder[T] = YamlDecoder.derived[T]
 inline def deriveYamlCodec[T](using m: Mirror.Of[T]): YamlCodec[T]     = YamlCodec.derived[T]
 
-extension (node: Node) def as[T](using c: YamlDecoder[T]): Either[YamlError, T] = c.construct(node)
-
 extension (str: String)
   /**
    * Parse YAML from the given [[String]], returning either [[YamlError]] or [[T]].
@@ -24,7 +22,10 @@ extension (str: String)
    * - then [[Composer]] produces a representation graph from events
    * - finally [[YamlDecoder]] (construct phase from the YAML spec) constructs data type [[T]] from the YAML representation. 
    */
-  def as[T](using c: YamlDecoder[T]): Either[YamlError, T] =
+  def as[T](using
+      c: YamlDecoder[T],
+      settings: LoadSettings = LoadSettings.empty
+  ): Either[YamlError, T] =
     for
       events <- {
         val parser = ParserImpl(Scanner(str))

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/YamlCodec.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/YamlCodec.scala
@@ -16,7 +16,9 @@ object YamlCodec:
       val decoder = YamlDecoder.derived[T]
       val encoder = YamlEncoder.derived[T]
 
-      def construct(node: Node): Either[ConstructError, T] = decoder.construct(node)
-      def asNode(obj: T): Node                             = encoder.asNode(obj)
+      def construct(node: Node)(using
+          settings: LoadSettings = LoadSettings.empty
+      ): Either[ConstructError, T] = decoder.construct(node)
+      def asNode(obj: T): Node     = encoder.asNode(obj)
 
 end YamlCodec

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/YamlEncoder.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/YamlEncoder.scala
@@ -21,21 +21,19 @@ object YamlEncoder:
   given YamlEncoder[String]  = v => Node.ScalarNode(v)
 
   given [T](using encoder: YamlEncoder[T]): YamlEncoder[Set[T]] = (nodes) =>
-    Node.SequenceNode(nodes.map(encoder.asNode(_)).toSeq)
+    Node.SequenceNode(nodes.map(encoder.asNode(_)).toSeq, Tag(""))
 
   given [T](using encoder: YamlEncoder[T]): YamlEncoder[Seq[T]] = (nodes) =>
-    Node.SequenceNode(nodes.map(encoder.asNode(_)))
+    Node.SequenceNode(nodes.map(encoder.asNode(_)), Tag(""))
 
   given [T](using encoder: YamlEncoder[T]): YamlEncoder[List[T]] = (nodes) =>
-    Node.SequenceNode(nodes.map(encoder.asNode(_)))
+    Node.SequenceNode(nodes.map(encoder.asNode(_)), Tag(""))
 
   // todo support arbitrary node as key in KeyValueNode
-  given [V](using valueCodec: YamlEncoder[V]): YamlEncoder[Map[String, V]] =
+  given [K, V](using keyCodec: YamlEncoder[K], valueCodec: YamlEncoder[V]): YamlEncoder[Map[K, V]] =
     (nodes) =>
-      val pairs = nodes.toList.map((key, value) =>
-        Node.KeyValueNode(Node.ScalarNode(key), valueCodec.asNode(value))
-      )
-      Node.MappingNode(pairs)
+      val mappings = nodes.map((key, value) => (keyCodec.asNode(key) -> valueCodec.asNode(value)))
+      Node.MappingNode(mappings)
 
   inline def derived[T](using m: Mirror.Of[T]): YamlEncoder[T] = inline m match
     case p: Mirror.ProductOf[T] => deriveProduct(p)
@@ -48,11 +46,15 @@ object YamlEncoder:
       override def asNode(obj: T): Node =
         val products = obj.asInstanceOf[Product].productIterator
         val nodes =
-          elemLabels.zip(products).zip(yamlEncoders).map { case ((label, element), encoder) =>
-            val key   = Node.ScalarNode(label)
-            val value = encoder.asInstanceOf[YamlEncoder[Any]].asNode(element)
-            Node.KeyValueNode(key, value)
-          }
+          elemLabels
+            .zip(products)
+            .zip(yamlEncoders)
+            .map { case ((label, element), encoder) =>
+              val key: Node = Node.ScalarNode(label)
+              val value     = encoder.asInstanceOf[YamlEncoder[Any]].asNode(element)
+              (key, value)
+            }
+            .toMap
         Node.MappingNode(nodes)
     }
 

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/YamlEncoder.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/YamlEncoder.scala
@@ -21,13 +21,13 @@ object YamlEncoder:
   given YamlEncoder[String]  = v => Node.ScalarNode(v)
 
   given [T](using encoder: YamlEncoder[T]): YamlEncoder[Set[T]] = (nodes) =>
-    Node.SequenceNode(nodes.map(encoder.asNode(_)).toSeq, Tag(""))
+    Node.SequenceNode(nodes.map(encoder.asNode(_)).toSeq, Tag.seq)
 
   given [T](using encoder: YamlEncoder[T]): YamlEncoder[Seq[T]] = (nodes) =>
-    Node.SequenceNode(nodes.map(encoder.asNode(_)), Tag(""))
+    Node.SequenceNode(nodes.map(encoder.asNode(_)), Tag.seq)
 
   given [T](using encoder: YamlEncoder[T]): YamlEncoder[List[T]] = (nodes) =>
-    Node.SequenceNode(nodes.map(encoder.asNode(_)), Tag(""))
+    Node.SequenceNode(nodes.map(encoder.asNode(_)), Tag.seq)
 
   // todo support arbitrary node as key in KeyValueNode
   given [K, V](using keyCodec: YamlEncoder[K], valueCodec: YamlEncoder[V]): YamlEncoder[Map[K, V]] =

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/YamlError.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/YamlError.scala
@@ -1,5 +1,6 @@
 package org.virtuslab.yaml
 
+import scala.reflect.ClassTag
 import scala.util.control.NoStackTrace
 
 import org.virtuslab.yaml.internal.load.reader.token.Token
@@ -20,12 +21,42 @@ object ParseError:
   )
   def from(expected: TokenKind, got: Token): ParseError = ParseError.from(expected.toString, got)
 
-final case class ComposerError(msg: String)  extends YamlError
+final case class ComposerError(msg: String) extends YamlError
+
 final case class ConstructError(msg: String) extends YamlError
-final case class ScannerError(msg: String)   extends Throwable with YamlError with NoStackTrace
+object ConstructError:
+  private def from(errorMsg: String, node: Option[Node], expected: Option[String]): ConstructError =
+    val msg = node.flatMap(_.pos) match
+      case Some(range) =>
+        s"""|$errorMsg
+            |at ${range.start.line}:${range.start.column},${expected.map(exp => s" expected $exp").getOrElse("")}
+            |${range.errorMsg} """.stripMargin
+      case None =>
+        errorMsg
+    ConstructError(msg)
+  def from(errorMsg: String, node: Node, expected: String): ConstructError =
+    from(errorMsg, Some(node), Some(expected))
+  def from(errorMsg: String, expected: String, node: Node): ConstructError =
+    from(errorMsg, Some(node), Some(expected))
+  def from(errorMsg: String, node: Node): ConstructError = from(errorMsg, Some(node), None)
+  def from(errorMsg: String, expected: String): ConstructError =
+    from(errorMsg, None, Some(expected))
+  def from(errorMsg: String): ConstructError = from(errorMsg, None, None)
+
+  def from(t: Throwable, node: Node, expected: String): ConstructError =
+    from(t.getMessage, Some(node), Some(expected))
+  def from(t: Throwable, expected: String, node: Node): ConstructError =
+    from(t.getMessage, Some(node), Some(expected))
+  def from(t: Throwable, node: Node): ConstructError = from(t.getMessage, Some(node), None)
+  def from(t: Throwable, expected: String): ConstructError =
+    from(t.getMessage, None, Some(expected))
+  def from(t: Throwable): ConstructError = from(t.getMessage, None, None)
+end ConstructError
+
+final case class ScannerError(msg: String) extends Throwable with YamlError with NoStackTrace
 object ScannerError:
   def from(obtained: String, got: Token): ScannerError = ScannerError(
     s"""|Obtained 
-        |$obtained but exptected got ${got.kind}
+        |$obtained but expected got ${got.kind}
         |${got.range.errorMsg}""".stripMargin
   )

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/dump/serialize/SerializerImpl.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/dump/serialize/SerializerImpl.scala
@@ -13,18 +13,14 @@ object SerializerImpl extends Serializer:
     case scalar: Node.ScalarNode     => convertScalarNode(scalar)
     case mapping: Node.MappingNode   => convertMappingNode(mapping)
     case sequence: Node.SequenceNode => convertSequenceNode(sequence)
-    case kv: Node.KeyValueNode       => convertKeyValueNode(kv)
 
   private def convertMappingNode(node: Node.MappingNode): Seq[EventKind] =
-    val events = node.mappings.map(convertNode(_)).flatten
+    val events = node.mappings.toSeq.flatMap((k, v) => Seq(convertNode(k), convertNode(v))).flatten
     Seq(MappingStart()) ++ events ++ Seq(MappingEnd)
 
   private def convertSequenceNode(node: Node.SequenceNode): Seq[EventKind] =
     val events = node.nodes.map(convertNode(_)).flatten
     Seq(SequenceStart()) ++ events ++ Seq(SequenceEnd)
-
-  private def convertKeyValueNode(node: Node.KeyValueNode): Seq[EventKind] =
-    convertNode(node.key) ++ convertNode(node.value)
 
   private def convertScalarNode(node: Node.ScalarNode): Seq[EventKind] =
     Seq(Scalar(node.value))

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
@@ -6,6 +6,7 @@ import org.virtuslab.yaml.ComposerError
 import org.virtuslab.yaml.Node
 import org.virtuslab.yaml.Position
 import org.virtuslab.yaml.Range
+import org.virtuslab.yaml.Tag
 import org.virtuslab.yaml.YamlError
 import org.virtuslab.yaml.internal.load.parse.Event
 import org.virtuslab.yaml.internal.load.parse.EventKind
@@ -37,7 +38,8 @@ object ComposerImpl extends Composer:
         case _: EventKind.SequenceStart                                => composeSequenceNode(tail)
         case _: EventKind.MappingStart | _: EventKind.FlowMappingStart => composeMappingNode(tail)
         case s: EventKind.Scalar =>
-          Right(Result(Node.ScalarNode(s.value, head.pos), tail))
+          val tag: Tag = s.metadata.tag.getOrElse(Tag.resolveTag(s.value))
+          Right(Result(Node.ScalarNode(s.value, tag, head.pos), tail))
         // todo #88
         case _: EventKind.Alias => Left(ComposerError(s"Aliases aren't currently supported"))
         case event              => Left(ComposerError(s"Expected YAML node, but found: $event"))
@@ -60,7 +62,7 @@ object ComposerImpl extends Composer:
           case Left(err)         => Left(err)
 
     parseChildren(events, Nil).map { case (Result(nodes, rest), pos) =>
-      Result(Node.SequenceNode(nodes, pos), rest)
+      Result(new Node.SequenceNode(nodes, Tag.seq, pos), rest)
     }
   }
 
@@ -68,9 +70,9 @@ object ComposerImpl extends Composer:
     @tailrec
     def parseMappings(
         events: List[Event],
-        mappings: List[Node.KeyValueNode],
+        mappings: List[(Node, Node)],
         firstChildPos: Option[Range] = None
-    ): ComposeResultWithPos[List[Node.KeyValueNode]] = {
+    ): ComposeResultWithPos[List[(Node, Node)]] = {
       events match
         case Nil => Left(ComposerError("Not found MappingEnd event for mapping"))
         case Event(EventKind.MappingEnd | EventKind.FlowMappingEnd, _) :: tail =>
@@ -86,14 +88,16 @@ object ComposerImpl extends Composer:
             for
               key <- composeNode(events)
               v   <- composeNode(key.remaining)
-            yield Result(Node.KeyValueNode(key.node, v.node, key.node.pos), v.remaining)
-
+            yield Result((key.node, v.node), v.remaining)
           mapping match
-            case Right(node, rest) => parseMappings(rest, mappings :+ node, node.pos)
-            case Left(err)         => Left(err)
+            case Right(node @ (key, value), rest) => parseMappings(rest, mappings :+ node, key.pos)
+            case Left(err)                        => Left(err)
     }
 
     parseMappings(events, Nil).map { case (Result(nodes, rest), pos) =>
-      Result(Node.MappingNode(nodes, pos), rest)
+      Result(
+        new Node.MappingNode(nodes.toMap, Tag.map, pos),
+        rest
+      )
     }
   }

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
@@ -62,7 +62,7 @@ object ComposerImpl extends Composer:
           case Left(err)         => Left(err)
 
     parseChildren(events, Nil).map { case (Result(nodes, rest), pos) =>
-      Result(new Node.SequenceNode(nodes, Tag.seq, pos), rest)
+      Result(Node.SequenceNode(nodes, Tag.seq, pos), rest)
     }
   }
 
@@ -96,7 +96,7 @@ object ComposerImpl extends Composer:
 
     parseMappings(events, Nil).map { case (Result(nodes, rest), pos) =>
       Result(
-        new Node.MappingNode(nodes.toMap, Tag.map, pos),
+        Node.MappingNode(nodes.toMap, Tag.map, pos),
         rest
       )
     }

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
@@ -62,7 +62,8 @@ end NodeEventMetadata
 object NodeEventMetadata:
   final val empty                              = NodeEventMetadata()
   def apply(anchor: Anchor): NodeEventMetadata = NodeEventMetadata(anchor = Some(anchor))
-  @scala.annotation.targetName("applyForTag")
+  def apply(anchor: Anchor, tag: Tag): NodeEventMetadata =
+    NodeEventMetadata(anchor = Some(anchor), tag = Some(tag))
   def apply(tag: Tag): NodeEventMetadata = NodeEventMetadata(tag = Some(tag))
 
 opaque type Anchor = String

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
@@ -2,6 +2,7 @@ package org.virtuslab.yaml.internal.load.parse
 
 import org.virtuslab.yaml.Node
 import org.virtuslab.yaml.Range
+import org.virtuslab.yaml.Tag
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 
 /** 
@@ -67,7 +68,3 @@ object NodeEventMetadata:
 opaque type Anchor = String
 object Anchor:
   def apply(anchor: String): Anchor = anchor
-
-opaque type Tag = String
-object Tag:
-  def apply(tag: String): Tag = tag

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
@@ -8,6 +8,7 @@ import scala.util.Try
 
 import org.virtuslab.yaml.ParseError
 import org.virtuslab.yaml.Range
+import org.virtuslab.yaml.Tag
 import org.virtuslab.yaml.YamlError
 import org.virtuslab.yaml.internal.load.TagHandle
 import org.virtuslab.yaml.internal.load.TagValue

--- a/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
+++ b/yaml/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
@@ -6,6 +6,8 @@ import scala.util.Failure
 import scala.util.Success
 import scala.util.Try
 
+import org.virtuslab.yaml.CoreSchemaTag
+import org.virtuslab.yaml.CustomTag
 import org.virtuslab.yaml.ParseError
 import org.virtuslab.yaml.Range
 import org.virtuslab.yaml.Tag
@@ -388,7 +390,7 @@ final class ParserImpl private (in: Tokenizer) extends Parser:
         case _ =>
           Right(
             Event(
-              EventKind.Scalar("", ScalarStyle.Plain, metadata),
+              EventKind.Scalar("", ScalarStyle.Plain, metadata.withTag(Tag.nullTag)),
               nextToken.range
             )
           )
@@ -407,14 +409,18 @@ final class ParserImpl private (in: Tokenizer) extends Parser:
           in.popToken()
           value match
             case TagValue.NonSpecific =>
-              parseNodeAttributes(in.peekToken(), metadata.withTag(Tag("!")))
+              parseNodeAttributes(in.peekToken(), metadata)
             case TagValue.Verbatim(value) =>
-              parseNodeAttributes(in.peekToken(), metadata.withTag(Tag(value)))
+              parseNodeAttributes(in.peekToken(), metadata.withTag(CustomTag(value)))
             case TagValue.Shorthand(handle, suffix) =>
               val handleKey = handle.value
               directives.get(handleKey) match
                 case Some(prefix) =>
-                  parseNodeAttributes(in.peekToken(), metadata.withTag(Tag(s"$prefix$suffix")))
+                  val tagValue = s"$prefix$suffix"
+                  val tag =
+                    if Tag.coreSchemaValues.contains(tagValue) then CoreSchemaTag(tagValue)
+                    else CustomTag(tagValue)
+                  parseNodeAttributes(in.peekToken(), metadata.withTag(tag))
                 case None =>
                   Left(ParseError(s"There is no registered tag directive for handle $handleKey"))
         case _ => Right(metadata, token)

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/ComposerSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/ComposerSuite.scala
@@ -34,7 +34,7 @@ class ComposerSuite extends munit.FunSuite:
     assertEquals(ComposerImpl.fromEvents(events), expected)
   }
 
-  test("mapping of scalars".only) {
+  test("mapping of scalars") {
     val events = List(
       StreamStart,
       DocumentStart(),

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/ComposerSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/ComposerSuite.scala
@@ -34,7 +34,7 @@ class ComposerSuite extends munit.FunSuite:
     assertEquals(ComposerImpl.fromEvents(events), expected)
   }
 
-  test("mapping of scalars") {
+  test("mapping of scalars".only) {
     val events = List(
       StreamStart,
       DocumentStart(),
@@ -52,9 +52,9 @@ class ComposerSuite extends munit.FunSuite:
 
     val expected = Right(
       MappingNode(
-        KeyValueNode(ScalarNode("hr"), ScalarNode("65")),
-        KeyValueNode(ScalarNode("avg"), ScalarNode("0.278")),
-        KeyValueNode(ScalarNode("rbi"), ScalarNode("147"))
+        ScalarNode("hr")  -> ScalarNode("65"),
+        ScalarNode("avg") -> ScalarNode("0.278"),
+        ScalarNode("rbi") -> ScalarNode("147")
       )
     )
 
@@ -85,23 +85,19 @@ class ComposerSuite extends munit.FunSuite:
 
     val expected = Right(
       MappingNode(
-        List(
-          KeyValueNode(
-            ScalarNode("american"),
+        Map(
+          ScalarNode("american") ->
             SequenceNode(
               ScalarNode("Boston Red Sox"),
               ScalarNode("Detroit Tigers"),
               ScalarNode("New York Yankees")
-            )
-          ),
-          KeyValueNode(
-            ScalarNode("national"),
+            ),
+          ScalarNode("national") ->
             SequenceNode(
               ScalarNode("New York Mets"),
               ScalarNode("Chicago Cubs"),
               ScalarNode("Atlanta Braves")
             )
-          )
         )
       )
     )
@@ -138,14 +134,14 @@ class ComposerSuite extends munit.FunSuite:
     val expected = Right(
       SequenceNode(
         MappingNode(
-          KeyValueNode(ScalarNode("name"), ScalarNode("Mark McGwire")),
-          KeyValueNode(ScalarNode("hr"), ScalarNode("65")),
-          KeyValueNode(ScalarNode("avg"), ScalarNode("0.278"))
+          ScalarNode("name") -> ScalarNode("Mark McGwire"),
+          ScalarNode("hr")   -> ScalarNode("65"),
+          ScalarNode("avg")  -> ScalarNode("0.278")
         ),
         MappingNode(
-          KeyValueNode(ScalarNode("name"), ScalarNode("Sammy Sosa")),
-          KeyValueNode(ScalarNode("hr"), ScalarNode("63")),
-          KeyValueNode(ScalarNode("avg"), ScalarNode("0.288"))
+          ScalarNode("name") -> ScalarNode("Sammy Sosa"),
+          ScalarNode("hr")   -> ScalarNode("63"),
+          ScalarNode("avg")  -> ScalarNode("0.288")
         )
       )
     )

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/ConstructSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/ConstructSuite.scala
@@ -46,7 +46,7 @@ class ConstructSuite extends munit.FunSuite:
     assertEquals(node.as[DummyClass], expectedConstructError)
   }
 
-  test("decode as Any".only) {
+  test("decode as Any") {
 
     val node = MappingNode(
       SequenceNode(1, 2) -> ScalarNode("seq")
@@ -55,9 +55,6 @@ class ConstructSuite extends munit.FunSuite:
     val expected = Map[Any, Any](
       Seq(1, 2) -> "seq"
     )
-
-    println(SequenceNode(1, 2))
-    println(node.as[Any])
 
     assertEquals(node.as[Any], Right(expected))
   }

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/ConstructSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/ConstructSuite.scala
@@ -45,3 +45,19 @@ class ConstructSuite extends munit.FunSuite:
       Left(ConstructError(s"Parameter of a class must be a scalar value"))
     assertEquals(node.as[DummyClass], expectedConstructError)
   }
+
+  test("decode as Any".only) {
+
+    val node = MappingNode(
+      SequenceNode(1, 2) -> ScalarNode("seq")
+    )
+
+    val expected = Map[Any, Any](
+      Seq(1, 2) -> "seq"
+    )
+
+    println(SequenceNode(1, 2))
+    println(node.as[Any])
+
+    assertEquals(node.as[Any], Right(expected))
+  }

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/ConstructSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/ConstructSuite.scala
@@ -15,19 +15,19 @@ class ConstructSuite extends munit.FunSuite:
 
   test("derive construct for case class") {
     val node = MappingNode(
-      KeyValueNode(ScalarNode("hr"), ScalarNode("65")),
-      KeyValueNode(ScalarNode("avg"), ScalarNode("0.278")),
-      KeyValueNode(ScalarNode("rbi"), ScalarNode("147"))
+      ScalarNode("hr")  -> ScalarNode("65"),
+      ScalarNode("avg") -> ScalarNode("0.278"),
+      ScalarNode("rbi") -> ScalarNode("147")
     )
     val expected = Right(Stats(65, 0.278, 147))
     assertEquals(node.as[Stats], expected)
   }
 
   test("derive construct for sealed trait") {
-    val foo = MappingNode(KeyValueNode(ScalarNode("value"), ScalarNode("65")))
+    val foo = MappingNode(ScalarNode("value") -> ScalarNode("65"))
     assertEquals(foo.as[SomeEnum], Right(SomeEnum.Foo(65)))
 
-    val bar = MappingNode(KeyValueNode(ScalarNode("price"), ScalarNode("65.997")))
+    val bar = MappingNode(ScalarNode("price") -> ScalarNode("65.997"))
     assertEquals(bar.as[SomeEnum], Right(SomeEnum.Bar(65.997)))
   }
 

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/decoder/DecoderErrorsSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/decoder/DecoderErrorsSuite.scala
@@ -17,7 +17,7 @@ class DecoderErrorsSuite extends BaseDecoderErrorSuite:
 
     assertError(
       yaml.as[Person],
-      s"""|For input string: "xxx"
+      s"""|Cannot parse xxx as Int
           |at 1:5, expected Int
           |age: xxx
           |     ^

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/decoder/DecoderSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/decoder/DecoderSuite.scala
@@ -1,8 +1,9 @@
 package org.virtuslab.yaml.decoder
 
+import org.virtuslab.yaml.Node.ScalarNode
 import org.virtuslab.yaml.*
 
-class PrimitiveDecoderSuite extends munit.FunSuite:
+class DecoderSuite extends munit.FunSuite:
 
   test("numbers") {
 
@@ -183,4 +184,50 @@ class PrimitiveDecoderSuite extends munit.FunSuite:
     )
 
     assertEquals(yaml.as[Spec], Right(expectedSpec))
+  }
+
+  test("decode into Map[Any, Any]") {
+
+    val yaml =
+      s"""|123: 321
+          |string: aezakmi
+          |true: false
+          |5.5: 55.55
+          |""".stripMargin
+
+    val expected = Map[Any, Any](
+      123      -> 321,
+      "string" -> "aezakmi",
+      true     -> false,
+      5.5      -> 55.55
+    )
+
+    assertEquals(yaml.as[Map[Any, Any]], Right(expected))
+  }
+
+  test("decode using custom tag".only) {
+    case class Custom(x: Int, doubledX: Int)
+
+    val yaml =
+      s"""|!Custom 5
+          |""".stripMargin
+
+    val expected = Custom(5, 10)
+
+    val decoder = new YamlDecoder[Custom] {
+      override def construct(node: Node)(using
+          settings: LoadSettings = LoadSettings.empty
+      ): Either[ConstructError, Custom] = node match {
+        case ScalarNode(value, _) =>
+          val int = value.toInt
+          Right(Custom(int, int * 2))
+        case _ => ???
+      }
+    }.asInstanceOf[YamlDecoder[Any]]
+
+    given settings: LoadSettings = LoadSettings(
+      Map(Tag("!Custom") -> decoder)
+    )
+
+    assertEquals(yaml.as[Any], Right(expected))
   }

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/decoder/DecoderSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/decoder/DecoderSuite.scala
@@ -205,7 +205,7 @@ class DecoderSuite extends munit.FunSuite:
     assertEquals(yaml.as[Map[Any, Any]], Right(expected))
   }
 
-  test("decode using custom tag".only) {
+  test("decode using custom tag") {
     case class Custom(x: Int, doubledX: Int)
 
     val yaml =
@@ -214,19 +214,13 @@ class DecoderSuite extends munit.FunSuite:
 
     val expected = Custom(5, 10)
 
-    val decoder = new YamlDecoder[Custom] {
-      override def construct(node: Node)(using
-          settings: LoadSettings = LoadSettings.empty
-      ): Either[ConstructError, Custom] = node match {
-        case ScalarNode(value, _) =>
-          val int = value.toInt
-          Right(Custom(int, int * 2))
-        case _ => ???
-      }
-    }.asInstanceOf[YamlDecoder[Any]]
+    val decoder = YamlDecoder[Custom] { case ScalarNode(value, _) =>
+      val int = value.toInt
+      Right(Custom(int, int * 2))
+    }
 
     given settings: LoadSettings = LoadSettings(
-      Map(Tag("!Custom") -> decoder)
+      Map(CustomTag("!Custom") -> decoder)
     )
 
     assertEquals(yaml.as[Any], Right(expected))

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/AnchorSpec.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/AnchorSpec.scala
@@ -89,7 +89,7 @@ class AnchorSpec extends BaseYamlSuite:
       DocumentStart(explicit = true),
       MappingStart(),
       Scalar("a"),
-      Scalar("", metadata = NodeEventMetadata(Anchor("anchor"))),
+      Scalar("", metadata = NodeEventMetadata(Anchor("anchor"), Tag.nullTag)),
       Scalar("b"),
       Alias(Anchor("anchor")),
       MappingEnd,

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/MappingSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/MappingSuite.scala
@@ -2,6 +2,7 @@ package org.virtuslab.yaml
 package parser
 
 import org.virtuslab.yaml.internal.load.parse.EventKind.*
+import org.virtuslab.yaml.internal.load.parse.NodeEventMetadata
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 
 class MappingSuite extends BaseYamlSuite:
@@ -151,7 +152,7 @@ class MappingSuite extends BaseYamlSuite:
       DocumentStart(),
       MappingStart(),
       Scalar("key"),
-      Scalar(""),
+      Scalar("", metadata = NodeEventMetadata(Tag.nullTag)),
       Scalar("key2"),
       Scalar("value"),
       MappingEnd,
@@ -172,7 +173,7 @@ class MappingSuite extends BaseYamlSuite:
       DocumentStart(),
       MappingStart(),
       Scalar("key"),
-      Scalar(""),
+      Scalar("", metadata = NodeEventMetadata(Tag.nullTag)),
       Scalar("period"),
       Scalar("10"),
       MappingEnd,
@@ -437,13 +438,13 @@ class MappingSuite extends BaseYamlSuite:
       SequenceStart(),
       FlowMappingStart(),
       Scalar("single line", ScalarStyle.DoubleQuoted),
-      Scalar(""),
+      Scalar("", metadata = NodeEventMetadata(Tag.nullTag)),
       Scalar("a"),
       Scalar("b"),
       FlowMappingEnd,
       FlowMappingStart(),
       Scalar("multi line", ScalarStyle.DoubleQuoted),
-      Scalar(""),
+      Scalar("", metadata = NodeEventMetadata(Tag.nullTag)),
       Scalar("a"),
       Scalar("b"),
       FlowMappingEnd,

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/TagSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/TagSuite.scala
@@ -1,11 +1,11 @@
 package org.virtuslab.yaml
 package parser
 
+import org.virtuslab.yaml.Tag
 import org.virtuslab.yaml.internal.load.parse.Anchor
 import org.virtuslab.yaml.internal.load.parse.EventKind
 import org.virtuslab.yaml.internal.load.parse.EventKind.*
 import org.virtuslab.yaml.internal.load.parse.NodeEventMetadata
-import org.virtuslab.yaml.internal.load.parse.Tag
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 
 class TagSuite extends BaseYamlSuite:

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/TagSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/parser/TagSuite.scala
@@ -1,7 +1,6 @@
 package org.virtuslab.yaml
 package parser
 
-import org.virtuslab.yaml.Tag
 import org.virtuslab.yaml.internal.load.parse.Anchor
 import org.virtuslab.yaml.internal.load.parse.EventKind
 import org.virtuslab.yaml.internal.load.parse.EventKind.*
@@ -22,13 +21,13 @@ class TagSuite extends BaseYamlSuite:
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
-      Scalar("bar", ScalarStyle.DoubleQuoted, NodeEventMetadata(Tag("!foo"))),
+      Scalar("bar", ScalarStyle.DoubleQuoted, NodeEventMetadata(CustomTag("!foo"))),
       DocumentEnd(explicit = true),
       DocumentStart(explicit = true),
       Scalar(
         "bar",
         ScalarStyle.DoubleQuoted,
-        NodeEventMetadata(Tag("tag:example.com,2000:app/foo"))
+        NodeEventMetadata(CustomTag("tag:example.com,2000:app/foo"))
       ),
       DocumentEnd(),
       StreamEnd
@@ -46,13 +45,13 @@ class TagSuite extends BaseYamlSuite:
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
-      Scalar("bar", ScalarStyle.DoubleQuoted, NodeEventMetadata(Tag("!foo"))),
+      Scalar("bar", ScalarStyle.DoubleQuoted, NodeEventMetadata(CustomTag("!foo"))),
       DocumentEnd(),
       DocumentStart(explicit = true),
       Scalar(
         "bar",
         ScalarStyle.DoubleQuoted,
-        NodeEventMetadata(Tag("tag:example.com,2000:app/foo"))
+        NodeEventMetadata(CustomTag("tag:example.com,2000:app/foo"))
       ),
       DocumentEnd(),
       StreamEnd
@@ -72,9 +71,9 @@ class TagSuite extends BaseYamlSuite:
       StreamStart,
       DocumentStart(explicit = true),
       SequenceStart(),
-      Scalar("foo", metadata = NodeEventMetadata(Tag("!local"))),
-      Scalar("bar", metadata = NodeEventMetadata(Tag("tag:yaml.org,2002:str"))),
-      Scalar("baz", metadata = NodeEventMetadata(Tag("tag:example.com,2000:app/tag!"))),
+      Scalar("foo", metadata = NodeEventMetadata(CustomTag("!local"))),
+      Scalar("bar", metadata = NodeEventMetadata(CoreSchemaTag("tag:yaml.org,2002:str"))),
+      Scalar("baz", metadata = NodeEventMetadata(CustomTag("tag:example.com,2000:app/tag!"))),
       SequenceEnd,
       DocumentEnd(),
       StreamEnd
@@ -89,7 +88,7 @@ class TagSuite extends BaseYamlSuite:
     val expectedEvents = List(
       StreamStart,
       DocumentStart(),
-      Scalar("a", metadata = NodeEventMetadata(Tag("!"))),
+      Scalar("a"),
       DocumentEnd(),
       StreamEnd
     )
@@ -106,7 +105,7 @@ class TagSuite extends BaseYamlSuite:
     val expectedEvents = List(
       StreamStart,
       DocumentStart(explicit = true),
-      SequenceStart(NodeEventMetadata(Tag("tag:yaml.org,2002:omap"))),
+      SequenceStart(NodeEventMetadata(CustomTag("tag:yaml.org,2002:omap"))),
       MappingStart(),
       Scalar("Mark McGwire"),
       Scalar("65"),
@@ -139,7 +138,7 @@ class TagSuite extends BaseYamlSuite:
       Scalar(
         "bar",
         ScalarStyle.DoubleQuoted,
-        NodeEventMetadata(Tag("tag:example.com,2000:app/foo"))
+        NodeEventMetadata(CustomTag("tag:example.com,2000:app/foo"))
       ),
       SequenceEnd,
       DocumentEnd(),

--- a/yaml/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TagSuite.scala
+++ b/yaml/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TagSuite.scala
@@ -1,7 +1,6 @@
 package org.virtuslab.yaml
 package tokenizer
 
-import org.virtuslab.yaml.*
 import org.virtuslab.yaml.internal.load.TagHandle
 import org.virtuslab.yaml.internal.load.TagPrefix
 import org.virtuslab.yaml.internal.load.TagValue


### PR DESCRIPTION
Each YAML node except its kind (scalar, mapping, sequence) has also a tag. Tag property indicates the type that the application should use to represent a given node. Typically, most tags are not explicitly specified in the character stream so YAML processor has to resolve them on its own using some schema. Recommended done is [core schema](https://yaml.org/spec/1.2.2/#core-schema).

- [ ] Add more testcases (e.g. all form [this chapter](https://yaml.org/spec/1.2.2/#chapter-10-recommended-schemas))
- [ ] `YamlDecoder` should be easier to create. It'll be good to have some factory functions which will reduce required boilerplate (maybe as a follow-up PR?)
