### PR TITLE
Do not publish for 2.12

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,11 +1,18 @@
 import BuildHelper._
 
-lazy val scala3Version = "3.0.2"
-lazy val projectName   = "scala-yaml"
+def scala3Version = "3.0.2"
+def projectName   = "scala-yaml"
+def localSnapshotVersion = "0.0.5-SNAPSHOT"
+def isCI = System.getenv("CI") != null
 
 inThisBuild(
   List(
     organization := "org.virtuslab",
+    scalaVersion := scala3Version,
+    version ~= { dynVer =>
+      if (isCI) dynVer
+      else localSnapshotVersion // only for local publishing
+    },
     homepage     := Some(url("https://github.com/VirtusLab/scala-yaml")),
     licenses := List(
       "Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")


### PR DESCRIPTION
I don't know why, but there are artifacts for 2.12 at the Maven Central repository - https://mvnrepository.com/artifact/org.virtuslab/scala-yaml.

Indeed, `publishLocal` was publishing artifacts for 2.12 too. 
Setting `scalaVersion := scala3Version` in `inThisBuild` fixed this issue.