### PR TITLE
Reenable Scala 3 Native build, drop to Scala 3.1.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,13 @@ jobs:
           java-version: 8
       - name: JVM tests
         if: matrix.platform == 'jvm'
-        run: sbt core/test
+        run: sbt +core/test
       - name: JS tests
         if: matrix.platform == 'js'
-        run: sbt coreJS/test
+        run: sbt +coreJS/test
       - name: Native tests
         if: matrix.platform == 'native'
-        run: sbt coreNative/test
+        run: sbt +coreNative/test
 
   publish:
     needs: test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        platform: ['jvm', 'js'] # TODO restore native
+        platform: ['jvm', 'js', 'native']
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 import BuildHelper._
 
-def scala3Version        = "3.2.0-RC2"
+def scala3Version        = "3.1.3"
+def scala2Version        = "2.13.9"
+def munitVersion         = "1.0.0-M6"
 def projectName          = "scala-yaml"
 def localSnapshotVersion = "0.0.5-SNAPSHOT"
 def isCI                 = System.getenv("CI") != null
@@ -8,7 +10,7 @@ def isCI                 = System.getenv("CI") != null
 inThisBuild(
   List(
     organization       := "org.virtuslab",
-    crossScalaVersions := Seq("2.13.8", scala3Version),
+    crossScalaVersions := Seq(scala2Version, scala3Version),
     scalaVersion       := scala3Version,
     version ~= { dynVer =>
       if (isCI) dynVer
@@ -37,46 +39,17 @@ inThisBuild(
 
 ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"
 
-lazy val core = crossProject(JSPlatform, JVMPlatform /*, NativePlatform*/ )
+lazy val core = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .crossType(CrossType.Full)
   .withoutSuffixFor(JVMPlatform)
   .settings(
     name := projectName,
     libraryDependencies ++= Seq(Deps.pprint % Test),
-
-    // see https://github.com/scala-native/scala-native/blob/master/docs/changelog/0.4.3-RC1.md#cannot-create-documentation-using-scaladoc-in-scala-native-sbt-project
-    Compile / doc / scalacOptions ~= { options =>
-      options.filterNot(_.startsWith("-Xplugin"))
-    }
-  )
-  .jsSettings(
     libraryDependencies ++= List(
-      "org.scalameta" %%% "munit"                  % "0.7.29"       % Test,
-      ("org.scala-js"  %% "scalajs-test-interface" % scalaJSVersion % Test)
-        .cross(CrossVersion.for3Use2_13),
-      ("org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion % Test)
-        .cross(CrossVersion.for3Use2_13)
+      "org.scalameta" %%% "munit" % munitVersion % Test
     )
   )
-  // .nativeSettings(
-  //   // skip native tests for now since upstream changes in munit are required
-  //   Test / compile / skip := true,
-  //   Test / test / skip    := true,
-
-  //   // set dummy directory with tests to avoid unnecessary errors
-  //   Test / unmanagedSourceDirectories := Nil
-
-  //   // libraryDependencies ++= List(
-  //   // ("org.scalameta" %% "munit"  % "0.7.29"  % Test).cross(CrossVersion.for3Use2_13),
-  //   // ("org.scala-native" %%% "test-interface" % nativeVersion  % Test).cross(CrossVersion.for3Use2_13),
-  //   // ),
-  // )
   .settings(docsSettings)
-  .jvmSettings(
-    libraryDependencies ++= List(
-      "org.scalameta" %% "munit" % "0.7.29" % Test
-    )
-  )
 
 lazy val integration = project
   .in(file("integration-tests"))
@@ -86,7 +59,7 @@ lazy val integration = project
     moduleName     := "integration",
     publish / skip := true,
     libraryDependencies ++= List(
-      "org.scalameta" %% "munit"  % "0.7.29",
+      "org.scalameta" %% "munit"  % munitVersion,
       "com.lihaoyi"   %% "os-lib" % "0.8.1",
       "com.lihaoyi"   %% "pprint" % "0.7.3"
     )

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 import BuildHelper._
 
 def scala3Version        = "3.1.3"
-def scala2Version        = "2.13.9"
+def scala2Version        = "2.13.8"
 def munitVersion         = "1.0.0-M6"
 def projectName          = "scala-yaml"
 def localSnapshotVersion = "0.0.5-SNAPSHOT"

--- a/core/shared/src/main/scala-3/org/virtuslab/yaml/YamlEncoderCrossCompat.scala
+++ b/core/shared/src/main/scala-3/org/virtuslab/yaml/YamlEncoderCrossCompat.scala
@@ -3,12 +3,14 @@ package org.virtuslab.yaml
 import scala.deriving.Mirror
 import scala.compiletime.*
 
-private[yaml] trait YamlEncoderCrossCompanionCompat {
+private[yaml] trait YamlEncoderCrossCompanionCompat extends EncoderMacros {
   inline def derived[T](using m: Mirror.Of[T]): YamlEncoder[T] = inline m match
     case p: Mirror.ProductOf[T] => deriveProduct(p)
     case s: Mirror.SumOf[T]     => deriveSum(s)
+}
 
-  private inline def deriveProduct[T](p: Mirror.ProductOf[T]): YamlEncoder[T] =
+private[yaml] trait EncoderMacros:
+  protected inline def deriveProduct[T](p: Mirror.ProductOf[T]): YamlEncoder[T] =
     new YamlEncoder[T] {
       val yamlEncoders = summonAll[p.MirroredElemTypes]
       val elemLabels   = getElemLabels[p.MirroredElemLabels]
@@ -27,7 +29,7 @@ private[yaml] trait YamlEncoderCrossCompanionCompat {
         Node.MappingNode(nodes)
     }
 
-  private inline def deriveSum[T](s: Mirror.SumOf[T]) =
+  protected inline def deriveSum[T](s: Mirror.SumOf[T]) =
     new YamlEncoder[T]:
       val yamlEncoders = summonSumOf[s.MirroredElemTypes].asInstanceOf[List[YamlEncoder[T]]]
       override def asNode(t: T): Node = {
@@ -35,20 +37,19 @@ private[yaml] trait YamlEncoderCrossCompanionCompat {
         yamlEncoders(index).asInstanceOf[YamlEncoder[Any]].asNode(t)
       }
 
-  private inline def summonSumOf[T <: Tuple]: List[YamlEncoder[_]] = inline erasedValue[T] match
+  protected inline def summonSumOf[T <: Tuple]: List[YamlEncoder[_]] = inline erasedValue[T] match
     case _: (t *: ts) =>
       summonFrom { case p: Mirror.ProductOf[`t`] =>
         deriveProduct(p) :: summonSumOf[ts]
       }
     case _: EmptyTuple => Nil
 
-  private inline def summonAll[T <: Tuple]: List[YamlEncoder[_]] = inline erasedValue[T] match {
+  inline def summonAll[T <: Tuple]: List[YamlEncoder[_]] = inline erasedValue[T] match {
     case _: EmptyTuple => Nil
     case _: (t *: ts)  => summonInline[YamlEncoder[t]] :: summonAll[ts]
   }
 
-  private inline def getElemLabels[T <: Tuple]: List[String] = inline erasedValue[T] match {
+  protected inline def getElemLabels[T <: Tuple]: List[String] = inline erasedValue[T] match {
     case _: EmptyTuple     => Nil
     case _: (head *: tail) => constValue[head].toString :: getElemLabels[tail]
   }
-}

--- a/project/BuildHelper.scala
+++ b/project/BuildHelper.scala
@@ -3,27 +3,32 @@ import sbt.Keys._
 
 object BuildHelper {
   lazy val docsSettings = Seq(
-    Compile / doc / scalacOptions ++= Seq(
-      "-project",
-      "Scala-yaml",
-      "-siteroot",
-      "docs",
-      "-project-version",
-      version.value,
-      "-project-logo",
-      "docs/logo.svg",
-      "-social-links:" +
-        "github::https://github.com/VirtusLab/scala-yaml," +
-        "twitter::https://twitter.com/VirtusLab",
-      "-project-footer",
-      s"Copyright (c) 2021, VirtusLab",
-      "-source-links:github://VirtusLab/scala-yaml",
-      "-revision",
-      "master"
-    ),
+    Compile / doc / scalacOptions ++= {
+      if (scalaBinaryVersion.value.startsWith("3")) {
+        Seq(
+          "-project",
+          "Scala-yaml",
+          "-siteroot",
+          "docs",
+          "-project-version",
+          version.value,
+          "-project-logo",
+          "docs/logo.svg",
+          "-social-links:" +
+            "github::https://github.com/VirtusLab/scala-yaml," +
+            "twitter::https://twitter.com/VirtusLab",
+          "-project-footer",
+          s"Copyright (c) 2021, VirtusLab",
+          "-source-links:github://VirtusLab/scala-yaml",
+          "-revision",
+          "master"
+        )
+      } else Seq.empty
+    },
     Compile / doc := {
       val out = (Compile / doc).value
-      IO.copyDirectory((Compile / doc / target).value, file("generated-docs"))
+      if (scalaBinaryVersion.value.startsWith("3"))
+        IO.copyDirectory((Compile / doc / target).value, file("generated-docs"))
       out
     }
   )

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -6,4 +6,4 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject"      % "1.2.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
 
 addSbtPlugin("org.scala-js"     % "sbt-scalajs"      % "1.10.0")
-addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.4")
+addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.5")


### PR DESCRIPTION
Additionally, fix errors on ~older~ Scala 3

I was hitting the following errors:

```scala
[error] -- Error: /Users/velvetbaldmime/projects/scala-yaml/core/shared/src/test/scala-3/org/virtuslab/yaml/BaseYamlEncoderSuite.scala:28:54
[error] 28 |    case class Data(int: Int, double: Double) derives YamlCodec
[error]    |                                                      ^
[error]    |undefined: YamlEncoderCrossCompanionCompat_this.deriveProduct # -1: TermRef(TermRef(NoPrefix,val YamlEncoderCrossCompanionCompat_this),deriveProduct) at inlining
[error]    |---------------------------------------------------------------------------
[error]    |Inline stack trace
[error]    |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
[error]    |This location contains code that was inlined from YamlEncoderCrossCompat.scala:8
[error]  8 |    case p: Mirror.ProductOf[T] => deriveProduct(p)
[error]    |                                   ^^^^^^^^^^^^^
[error]     ---------------------------------------------------------------------------
[error] one error found
[error] (core / Test / compileIncremental) Compilation failed
```

Not sure if it's a regression on Scala 3 or what, but I think it'd be prudent to have a 3.1.x release first.