### PR TITLE
No-publish the root

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,6 +6,8 @@ def projectName          = "scala-yaml"
 def localSnapshotVersion = "0.0.6-SNAPSHOT"
 def isCI                 = System.getenv("CI") != null
 
+enablePlugins(NoPublishPlugin)
+
 inThisBuild(
   List(
     organization       := "org.virtuslab",
@@ -62,7 +64,6 @@ lazy val integration = project
   .settings(
     name           := "integration",
     moduleName     := "integration",
-    publish / skip := true,
     libraryDependencies ++= List(
       Deps.munit,
       Deps.osLib,
@@ -70,3 +71,4 @@ lazy val integration = project
     )
   )
   .settings(docsSettings)
+  .enablePlugins(NoPublishPlugin)

--- a/project/plugin.sbt
+++ b/project/plugin.sbt
@@ -11,3 +11,5 @@ addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "1.10.1")
 
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.7")
+
+addSbtPlugin("org.typelevel" % "sbt-typelevel-no-publish" % "0.4.15")


### PR DESCRIPTION
Pretty sure this fixes https://github.com/VirtusLab/scala-yaml/issues/177. The (empty) root project was being published with the same name as the core module, causing it to overwrite with an empty jar.