### PR TITLE
small tweaks in tokenizer

### DIFF
--- a/core/shared/src/main/scala/org/virtuslab/yaml/Yaml.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/Yaml.scala
@@ -5,7 +5,7 @@ import org.virtuslab.yaml.internal.dump.serialize.SerializerImpl
 import org.virtuslab.yaml.internal.load.compose.ComposerImpl
 import org.virtuslab.yaml.internal.load.parse.Parser
 import org.virtuslab.yaml.internal.load.parse.ParserImpl
-import org.virtuslab.yaml.internal.load.reader.Scanner
+import org.virtuslab.yaml.internal.load.reader.Tokenizer
 
 package object yaml {
 
@@ -25,7 +25,7 @@ package object yaml {
     ): Either[YamlError, T] =
       for {
         events <- {
-          val parser = ParserImpl(new Scanner(str))
+          val parser = ParserImpl(Tokenizer.make(str))
           parser.getEvents()
         }
         node <- ComposerImpl.fromEvents(events)
@@ -35,7 +35,7 @@ package object yaml {
     def asNode: Either[YamlError, Node] =
       for {
         events <- {
-          val parser = ParserImpl(new Scanner(str))
+          val parser = ParserImpl(Tokenizer.make(str))
           parser.getEvents()
         }
         node <- ComposerImpl.fromEvents(events)

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
@@ -14,7 +14,6 @@ import org.virtuslab.yaml.internal.load.parse.Event
 import org.virtuslab.yaml.internal.load.parse.EventKind
 import org.virtuslab.yaml.internal.load.parse.NodeEventMetadata
 import org.virtuslab.yaml.internal.load.parse.ParserImpl
-import org.virtuslab.yaml.internal.load.reader.Scanner
 
 /**
  * Composing takes a series of serialization events and produces a representation graph. 

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
@@ -57,7 +57,7 @@ private[yaml] class StringReader(in: String) extends Reader {
 
   override def peek(n: Int = 0): Char =
     if (offset + n < in.length) in.charAt(offset + n)
-    else '\u0000'
+    else Reader. nullTerminator
 
   private def nextLine() = { column = 0; line += 1 }
   private def skipAndMantainPosition() = {

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
@@ -57,7 +57,7 @@ private[yaml] class StringReader(in: String) extends Reader {
 
   override def peek(n: Int = 0): Char =
     if (offset + n < in.length) in.charAt(offset + n)
-    else Reader. nullTerminator
+    else Reader.nullTerminator
 
   private def nextLine() = { column = 0; line += 1 }
   private def skipAndMantainPosition() = {

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
@@ -7,23 +7,43 @@ import org.virtuslab.yaml.Position
 import org.virtuslab.yaml.Range
 
 trait Reader {
+
+  /** Read current character and advance by 1 position
+    * @return current character or '\u0000' in case there are no chars left
+    */
   def read(): Char
-  def peek(n: Int = 0): Option[Char]
-  def peekNext(): Option[Char]
-  def peekN(n: Int): String
-  def isWhitespace: Boolean
-  def isNextWhitespace: Boolean
-  def isNewline: Boolean
-  def isNextNewline: Boolean
-  def skipCharacter(): Unit
-  def skipN(n: Int): Unit
-  def skipWhitespaces(): Unit
+
+  /** Read current character without advancing
+    * @return current character or '\u0000' in case there are no chars left
+    */
+  def peek(n: Int = 0): Char
 
   def line: Int
   def column: Int
   def offset: Int
   def pos: Position
   def range: Range
+
+  def skipCharacter(): Unit
+  def skipN(n: Int): Unit
+  def skipWhitespaces(): Unit
+
+  final def peekNext(): Char          = peek(1)
+  final def peekN(n: Int): String     = (0 until n).map(peek(_)).mkString("")
+  final def isWhitespace: Boolean     = peek().isWhitespace
+  final def isNextWhitespace: Boolean = peekNext().isWhitespace
+  final def isNewline: Boolean        = isNewlineN(0)
+  final def isNextNewline: Boolean    = isNewlineN(1)
+
+  private def isNewlineN(n: Int): Boolean = {
+    val c = peek(n)
+    c == '\n' || isWindowsNewline(c)
+  }
+  protected def isWindowsNewline(c: Char): Boolean = c == '\r' && peekNext() == '\n'
+}
+
+object Reader {
+  final val nullTerminator: Char = '\u0000'
 }
 
 private[yaml] class StringReader(in: String) extends Reader {
@@ -35,18 +55,9 @@ private[yaml] class StringReader(in: String) extends Reader {
   override def pos   = Position(offset, line, column)
   override def range = Range(pos, lines)
 
-  override def peek(n: Int = 0): Option[Char] =
-    if (offset + n < in.length) Some(in.charAt(offset + n))
-    else None
-
-  override def peekNext(): Option[Char] = peek(1)
-  override def peekN(n: Int): String    = (0 until n).map(peek(_)).flatten.mkString("")
-  override def isWhitespace             = peek().exists(_.isWhitespace)
-  override def isNextWhitespace         = peekNext().exists(_.isWhitespace)
-  override def isNewline                = peek().exists(c => c == '\n' || isWindowsNewline(c))
-  override def isNextNewline            = peekNext().exists(c => c == '\n' || isWindowsNewline(c))
-
-  private def isWindowsNewline(c: Char) = c == '\r' && peekNext().exists(_ == '\n')
+  override def peek(n: Int = 0): Char =
+    if (offset + n < in.length) in.charAt(offset + n)
+    else '\u0000'
 
   private def nextLine() = { column = 0; line += 1 }
   private def skipAndMantainPosition() = {

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
@@ -25,7 +25,11 @@ trait Tokenizer {
   def popToken(): Token
 }
 
-private[yaml] class Scanner(str: String) extends Tokenizer {
+object Tokenizer {
+  def make(str: String): Tokenizer = new StringTokenizer(str)
+}
+
+private class StringTokenizer(str: String) extends Tokenizer {
 
   private val ctx = ReaderCtx(str)
   private val in  = ctx.reader

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
@@ -31,7 +31,7 @@ object Tokenizer {
 
 private class StringTokenizer(str: String) extends Tokenizer {
 
-  private val ctx = ReaderCtx(str)
+  private val ctx = TokenizerContext(str)
   private val in  = ctx.reader
 
   override def peekToken(): Either[YamlError, Token] = ctx.tokens.headOption match {

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
@@ -253,7 +253,8 @@ private class StringTokenizer(str: String) extends Tokenizer {
       }
       while (condition) sb.append(in.read())
 
-      if (invalidChars.contains(in.peek())) throw ScannerError.from(in.range, "Invalid character in tag")
+      if (invalidChars.contains(in.peek()))
+        throw ScannerError.from(in.range, "Invalid character in tag")
       UrlDecoder.decode(sb.result())
     }
 
@@ -286,7 +287,8 @@ private class StringTokenizer(str: String) extends Tokenizer {
     in.skipCharacter() // skip first '!'
     val peeked = in.peek()
     val tag: Tag = peeked match {
-      case Reader.nullTerminator => throw ScannerError.from(in.range, "Input stream ended unexpectedly")
+      case Reader.nullTerminator =>
+        throw ScannerError.from(in.range, "Input stream ended unexpectedly")
       case '<' =>
         val tag = parseVerbatimTag()
         Tag(TagValue.Verbatim(tag))

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
@@ -64,37 +64,36 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
       else closedBlockTokens
     val peeked = in.peek()
     val tokens: List[Token] = peeked match {
-      case Some('-') if isDocumentStart     => parseDocumentStart()
-      case Some('-') if in.isNextWhitespace => parseBlockSequence()
-      case Some('.') if isDocumentEnd       => parseDocumentEnd()
-      case Some('[')                        => parseFlowSequenceStart()
-      case Some(']')                        => parseFlowSequenceEnd()
-      case Some('{')                        => parseFlowMappingStart()
-      case Some('}')                        => parseFlowMappingEnd()
-      case Some('&')                        => parseAnchor()
-      case Some('!')                        => parseTag()
-      case Some('%')                        => parseDirective()
-      case Some('"')                        => parseDoubleQuoteValue()
-      case Some('\'')                       => parseSingleQuoteValue()
-      case Some('>')                        => parseFoldedValue()
-      case Some('|')                        => parseLiteral()
-      case Some('*')                        => parseAlias()
-      case Some(',') =>
+      case Reader.nullTerminator =>
+        ctx.popPotentialKeys() ++ ctx.checkIndents(-1) ++ List(Token(StreamEnd, in.range))
+      case '-' if isDocumentStart     => parseDocumentStart()
+      case '-' if in.isNextWhitespace => parseBlockSequence()
+      case '.' if isDocumentEnd       => parseDocumentEnd()
+      case '['                        => parseFlowSequenceStart()
+      case ']'                        => parseFlowSequenceEnd()
+      case '{'                        => parseFlowMappingStart()
+      case '}'                        => parseFlowMappingEnd()
+      case '&'                        => parseAnchor()
+      case '!'                        => parseTag()
+      case '%'                        => parseDirective()
+      case '"'                        => parseDoubleQuoteValue()
+      case '\''                       => parseSingleQuoteValue()
+      case '>'                        => parseFoldedValue()
+      case '|'                        => parseLiteral()
+      case '*'                        => parseAlias()
+      case ',' =>
         in.skipCharacter()
         ctx.isPlainKeyAllowed = true
         ctx.popPotentialKeys() ++ List(Token(Comma, in.range))
-      case Some(':')
-          if (in.isNextWhitespace || (ctx.isInFlowCollection && ctx.isPlainKeyAllowed)) =>
+      case ':' if (in.isNextWhitespace || (ctx.isInFlowCollection && ctx.isPlainKeyAllowed)) =>
         fetchValue()
-      case Some(_) => parsePlainScalar()
-      case None =>
-        ctx.popPotentialKeys() ++ ctx.checkIndents(-1) ++ List(Token(StreamEnd, in.range))
+      case _ => parsePlainScalar()
     }
     closedTokens ++ tokens
   }
 
   private def isDocumentStart =
-    in.peekN(3) == "---" && in.peek(3).exists(_.isWhitespace)
+    in.peekN(3) == "---" && in.peek(3).isWhitespace
 
   private def parseDocumentStart() = {
     in.skipN(4)
@@ -102,7 +101,7 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
   }
 
   private def isDocumentEnd =
-    in.peekN(3) == "..." && in.peek(3).exists(_.isWhitespace)
+    in.peekN(3) == "..." && in.peek(3).isWhitespace
 
   private def parseDocumentEnd() = {
     in.skipN(4)
@@ -156,16 +155,20 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
     def parseTagDirective() = {
       def parseTagHandle() = {
         in.peekNext() match { // peeking next char!! current char is exclamation mark
-          case Some(' ') =>
+          case ' ' =>
             in.skipCharacter() // skip exclamation mark
             TagHandle.Primary
-          case Some('!') =>
+          case '!' =>
             in.skipN(2) // skip both exclamation marks
             TagHandle.Secondary
           case _ =>
             val sb = new StringBuilder
             sb.append(in.read())
-            while (in.peek().exists(c => !c.isWhitespace && c != '!')) sb.append(in.read())
+            def condition = {
+              val c = in.peek()
+              !c.isWhitespace && c != '!'
+            }
+            while (condition) { sb.append(in.read()) }
             sb.append(in.read())
             TagHandle.Named(sb.result())
         }
@@ -174,13 +177,13 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
       def parseTagPrefix() = {
         skipSpaces()
         in.peek() match {
-          case Some('!') =>
+          case '!' =>
             val sb = new StringBuilder
-            while (in.peek().exists(c => !c.isWhitespace)) sb.append(in.read())
+            while (!in.peek().isWhitespace) { sb.append(in.read()) }
             TagPrefix.Local(sb.result())
-          case Some(char) if char != '!' && char != ',' =>
+          case char if char != '!' && char != ',' =>
             val sb = new StringBuilder
-            while (in.peek().exists(c => !c.isWhitespace)) sb.append(in.read())
+            while (!in.peek().isWhitespace) { sb.append(in.read()) }
             TagPrefix.Global(sb.result())
           case _ => throw ScannerError.from(in.range, "Invalid tag prefix in TAG directive")
         }
@@ -188,7 +191,7 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
 
       skipSpaces()
       in.peek() match {
-        case Some('!') =>
+        case '!' =>
           val handle = parseTagHandle()
           val prefix = parseTagPrefix()
           List(Token(TokenKind.TagDirective(handle, prefix), range))
@@ -198,10 +201,10 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
     }
 
     in.peek() match {
-      case Some('Y') if in.peekN(4) == "YAML" =>
+      case 'Y' if in.peekN(4) == "YAML" =>
         in.skipN(4)
         parseYamlDirective()
-      case Some('T') if in.peekN(3) == "TAG" =>
+      case 'T' if in.peekN(3) == "TAG" =>
         in.skipN(3)
         parseTagDirective()
       case _ => throw ScannerError.from(in.range, "Unknown directive, expected YAML or TAG")
@@ -215,9 +218,13 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
     def parseVerbatimTag(): String = {
       val sb = new StringBuilder
       sb.append('!')
-      while (in.peek().exists(c => c != '>' && !c.isWhitespace)) sb.append(in.read())
+      def condition = {
+        val c = in.peek()
+        c != '>' && !c.isWhitespace
+      }
+      while (condition) sb.append(in.read())
       in.peek() match {
-        case Some('>') =>
+        case '>' =>
           sb.append(in.read())
           sb.result()
         case _ => throw ScannerError.from(in.range, "Lacks '>' which closes verbatim tag attribute")
@@ -226,9 +233,13 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
 
     def parseTagSuffix(): String = {
       val sb = new StringBuilder
-      while (in.peek().exists(c => !invalidChars(c) && !c.isWhitespace)) sb.append(in.read())
-      if (in.peek().exists(c => invalidChars(c)))
-        throw ScannerError.from(in.range, "Invalid character in tag")
+      def condition = {
+        val c = in.peek()
+        !invalidChars(c) && !c.isWhitespace
+      }
+      while (condition) sb.append(in.read())
+
+      if (invalidChars.contains(in.peek())) throw ScannerError.from(in.range, "Invalid character in tag")
       UrlDecoder.decode(sb.result())
     }
 
@@ -239,17 +250,20 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
           TagValue.Shorthand(TagHandle.Secondary, parseTagSuffix())
         case _ => // tag handle starts with '!<char>' where char isn't space
           val sb = new StringBuilder
-
-          while (in.peek().exists(c => !invalidChars(c) && !c.isWhitespace && c != '!'))
+          def condition = {
+            val c = in.peek()
+            !invalidChars(c) && !c.isWhitespace && c != '!'
+          }
+          while (condition)
             sb.append(in.read())
-          if (in.peek().exists(c => invalidChars(c)))
+          if (invalidChars.contains(in.peek()))
             throw ScannerError.from(in.range, "Invalid character in tag")
           in.peek() match {
-            case Some('!') =>
+            case '!' =>
               sb.insert(0, '!')    // prepend already skipped exclamation mark
               sb.append(in.read()) // append ending exclamation mark
               TagValue.Shorthand(TagHandle.Named(sb.result()), parseTagSuffix())
-            case Some(' ') =>
+            case ' ' =>
               TagValue.Shorthand(TagHandle.Primary, sb.result())
             case _ => throw ScannerError.from(in.range, "Invalid tag handle")
           }
@@ -258,15 +272,15 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
     in.skipCharacter() // skip first '!'
     val peeked = in.peek()
     val tag: Tag = peeked match {
-      case Some('<') =>
+      case Reader.nullTerminator => throw ScannerError.from(in.range, "Input stream ended unexpectedly")
+      case '<' =>
         val tag = parseVerbatimTag()
         Tag(TagValue.Verbatim(tag))
-      case Some(' ') =>
+      case ' ' =>
         Tag(TagValue.NonSpecific)
-      case Some(char) =>
+      case char =>
         val tagValue = parseShorthandTag(char)
         Tag(tagValue)
-      case None => throw ScannerError.from(in.range, "Input stream ended unexpectedly")
     }
 
     if (ctx.isPlainKeyAllowed) {
@@ -282,7 +296,8 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
     @tailrec
     def readAnchorName(): String =
       in.peek() match {
-        case Some(char) if !invalidChars(char) && !in.isWhitespace =>
+        case Reader.nullTerminator => sb.result()
+        case char if !invalidChars(char) && !in.isWhitespace =>
           sb.append(in.read())
           readAnchorName()
         case _ => sb.result()
@@ -318,22 +333,22 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
     @tailrec
     def readScalar(): String =
       in.peek() match {
+        case Reader.nullTerminator =>
+          sb.result()
         case _ if in.isNewline =>
           skipUntilNextToken()
           sb.append(" ")
           readScalar()
-        case Some('\\') if in.peekNext() == Some('"') =>
+        case '\\' if in.peekNext() == '"' =>
           in.skipN(2)
           sb.append("\"")
           readScalar()
-        case Some('"') =>
+        case '"' =>
           in.skipCharacter()
           sb.result()
-        case Some(char) =>
+        case char =>
           sb.append(in.read())
           readScalar()
-        case None =>
-          sb.result()
       }
 
     val isPlainKeyAllowed = ctx.isPlainKeyAllowed
@@ -352,10 +367,10 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
    * This header is followed by a non-content line break with an optional comment.
    */
   private def parseBlockHeader(): Unit = {
-    while (in.peek() == Some(' '))
+    while (in.peek() == ' ')
       in.skipCharacter()
 
-    if (in.peek() == Some('#'))
+    if (in.peek() == '#')
       skipComment()
 
     if (in.isNewline) in.skipCharacter()
@@ -366,10 +381,10 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
    */
   private def parseChompingIndicator(): BlockChompingIndicator =
     in.peek() match {
-      case Some('-') =>
+      case '-' =>
         in.skipCharacter()
         BlockChompingIndicator.Strip
-      case Some('+') =>
+      case '+' =>
         in.skipCharacter()
         BlockChompingIndicator.Keep
       case _ => BlockChompingIndicator.Clip
@@ -377,7 +392,7 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
 
   private def parseIndentationIndicator(): Option[Int] =
     in.peek() match {
-      case Some(number) if number.isDigit =>
+      case number if number.isDigit =>
         in.skipCharacter()
         Some(number.asDigit)
       case _ => None
@@ -402,16 +417,16 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
     @tailrec
     def readLiteral(): String =
       in.peek() match {
+        case Reader.nullTerminator => sb.result()
         case _ if in.isNewline =>
           ctx.isPlainKeyAllowed = true
           sb.append(in.read())
           skipUntilNextIndent(foldedIndent)
           if (!in.isWhitespace && in.column != foldedIndent) sb.result()
           else readLiteral()
-        case Some(char) =>
+        case char =>
           sb.append(in.read())
           readLiteral()
-        case None => sb.result()
       }
 
     val scalar        = readLiteral()
@@ -443,11 +458,12 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
     @tailrec
     def readFolded(): String =
       in.peek() match {
+        case Reader.nullTerminator => sb.result()
         case _ if in.isNewline =>
           ctx.isPlainKeyAllowed = true
           if (in.isNextNewline) {
             chompedEmptyLines()
-            if (in.peek().isDefined) {
+            if (in.peek() != Reader.nullTerminator) {
               in.skipCharacter()
               skipUntilNextIndent(foldedIndent)
             }
@@ -455,7 +471,7 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
           } else {
             in.skipCharacter()
             skipUntilNextIndent(foldedIndent)
-            if (in.column != foldedIndent || in.peek() == None) {
+            if (in.column != foldedIndent || in.peek() == Reader.nullTerminator) {
               sb.append("\n")
               sb.result()
             } else {
@@ -463,10 +479,9 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
               readFolded()
             }
           }
-        case Some(char) =>
+        case char =>
           sb.append(in.read())
           readFolded()
-        case None => sb.result()
       }
 
     val scalar        = readFolded()
@@ -480,21 +495,21 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
     @tailrec
     def readScalar(): String =
       in.peek() match {
-        case Some('\'') if in.peekNext() == Some('\'') =>
+        case Reader.nullTerminator => sb.result()
+        case '\'' if in.peekNext() == '\'' =>
           in.skipN(2)
           sb.append('\'')
           readScalar()
-        case Some('\n') =>
+        case '\n' =>
           sb.append(' ')
           skipUntilNextToken()
           readScalar()
-        case Some('\'') =>
+        case '\'' =>
           in.skipCharacter()
           sb.result()
-        case Some(char) =>
+        case char =>
           sb.append(in.read())
           readScalar()
-        case None => sb.result()
       }
 
     val isPlainKeyAllowed = ctx.isPlainKeyAllowed
@@ -522,11 +537,12 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
     def readScalar(): String = {
       val peeked = in.peek()
       peeked match {
-        case Some(':') if in.isNextWhitespace                                      => sb.result()
-        case Some(':') if in.peekNext().exists(_ == ',') && ctx.isInFlowCollection => sb.result()
-        case Some(char) if !ctx.isAllowedSpecialCharacter(char)                    => sb.result()
-        case _ if isDocumentEnd || isDocumentStart                                 => sb.result()
-        case Some(' ') if in.peekNext() == Some('#')                               => sb.result()
+        case Reader.nullTerminator => sb.result()
+        case ':' if in.isNextWhitespace                            => sb.result()
+        case ':' if in.peekNext() == ',' && ctx.isInFlowCollection => sb.result()
+        case char if !ctx.isAllowedSpecialCharacter(char)          => sb.result()
+        case _ if isDocumentEnd || isDocumentStart                 => sb.result()
+        case ' ' if in.peekNext() == '#'                           => sb.result()
         case _ if in.isNewline =>
           ctx.isPlainKeyAllowed = true
           if (in.isNextNewline) chompedEmptyLines()
@@ -535,10 +551,9 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
           if (in.column > ctx.indent)
             readScalar()
           else sb.result()
-        case Some(char) =>
+        case char =>
           sb.append(in.read())
           readScalar()
-        case Some(_) | None => sb.result()
       }
     }
 
@@ -584,7 +599,7 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
   def skipUntilNextToken(): Unit = {
     while (in.isWhitespace && !in.isNewline) in.skipCharacter()
 
-    if (in.peek() == Some('#')) skipComment()
+    if (in.peek() == '#') skipComment()
 
     if (in.isNewline) {
       ctx.isPlainKeyAllowed = true
@@ -594,14 +609,14 @@ private[yaml] class Scanner(str: String) extends Tokenizer {
   }
 
   def skipSpaces(): Unit =
-    while (in.peek().contains(' ')) in.skipCharacter()
+    while (in.peek() == ' ') in.skipCharacter()
 
   def skipUntilNextIndent(indentBlock: Int): Unit =
-    while (in.peek() == Some(' ') && in.column < indentBlock) in.skipCharacter()
+    while (in.peek() == ' ' && in.column < indentBlock) in.skipCharacter()
 
   def skipUntilNextChar() =
     while (in.isWhitespace) in.skipCharacter()
 
-  private def skipComment(): Unit = while (in.peek().isDefined && !in.isNewline)
+  private def skipComment(): Unit = while (in.peek() != Reader.nullTerminator && !in.isNewline)
     in.skipCharacter()
 }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/TokenizerContext.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/TokenizerContext.scala
@@ -57,7 +57,7 @@ private[reader] case class TokenizerContext(reader: Reader) {
   def isInFlowMapping: Boolean    = flowMappingLevel > 0
   def isInFlowSequence: Boolean   = flowSequenceLevel > 0
   def isInFlowCollection: Boolean = isInFlowMapping || isInFlowSequence
-  
+
   def isInBlockCollection: Boolean = !isInFlowCollection
 
   def parseDocumentStart(indent: Int): List[Token] =

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/TokenizerContext.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/TokenizerContext.scala
@@ -57,8 +57,8 @@ private[reader] case class TokenizerContext(reader: Reader) {
   def isInFlowMapping: Boolean    = flowMappingLevel > 0
   def isInFlowSequence: Boolean   = flowSequenceLevel > 0
   def isInFlowCollection: Boolean = isInFlowMapping || isInFlowSequence
-
-  def isInBlockCollection = !isInFlowCollection
+  
+  def isInBlockCollection: Boolean = !isInFlowCollection
 
   def parseDocumentStart(indent: Int): List[Token] =
     checkIndents(-1) ++ List(Token(DocumentStart, reader.range))

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/TokenizerContext.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/TokenizerContext.scala
@@ -10,9 +10,9 @@ import org.virtuslab.yaml.internal.load.reader.StringReader
 import org.virtuslab.yaml.internal.load.reader.token.Token
 import org.virtuslab.yaml.internal.load.reader.token.TokenKind._
 
-case class ReaderCtx(reader: Reader) {
-  val tokens                     = mutable.ArrayDeque.empty[Token]
-  val potentialKeys              = mutable.ArrayDeque.empty[Token]
+private[reader] case class TokenizerContext(reader: Reader) {
+  val tokens = mutable.ArrayDeque.empty[Token]
+
   var isPlainKeyAllowed: Boolean = true
   private val indentations       = mutable.ArrayDeque.empty[Int]
   private var flowSequenceLevel  = 0
@@ -22,11 +22,17 @@ case class ReaderCtx(reader: Reader) {
   def addIndent(newIndent: Int): Unit = indentations.append(newIndent)
   def removeLastIndent(): Unit        = if (indentations.nonEmpty) indentations.removeLast()
 
-  def popPotentialKeys(): List[Token] = {
-    val plainKeys = potentialKeys.toList
-    potentialKeys.removeAll()
-    plainKeys
-  }
+  /**
+    * Stores tokens which might be assosiated with simple key (scalar). Such key might start with
+    * - tag
+    * - anchor
+    * - alias
+    * - scalar
+    */
+  val potentialKeys                     = mutable.ArrayDeque.empty[Token]
+  def addPotentialKey(key: Token): Unit = potentialKeys.addOne(key)
+  def popPotentialKeys(): List[Token]   = potentialKeys.removeAll().toList
+  def potentialKeyOpt: Option[Token]    = potentialKeys.headOption
 
   def needMoreTokens(): Boolean =
     tokens.isEmpty || potentialKeys.nonEmpty
@@ -61,6 +67,6 @@ case class ReaderCtx(reader: Reader) {
     popPotentialKeys() ++ checkIndents(-1) ++ List(Token(DocumentEnd, reader.range))
 }
 
-object ReaderCtx {
-  def apply(in: String): ReaderCtx = ReaderCtx(new StringReader(in))
+private[reader] object TokenizerContext {
+  def apply(in: String): TokenizerContext = TokenizerContext(new StringReader(in))
 }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/BlockChompingIndicator.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/BlockChompingIndicator.scala
@@ -1,5 +1,19 @@
 package org.virtuslab.yaml.internal.load.reader.token
 
+/** Chomping controls how final line breaks and trailing empty lines are interpreted. YAML provides
+  * three chomping methods:
+  *
+  * 1. Strip - stripping is specified by the “-” chomping indicator. In this case, the final line
+  * break and any trailing empty lines are excluded from the scalar’s content.
+  *
+  * 2. Clip - clipping is the default behavior used if no explicit chomping indicator is specified.
+  * In this case, the final line break character is preserved in the scalar’s content. However, any
+  * trailing empty lines are excluded from the scalar’s content.
+  *
+  * 3. Keep - keeping is specified by the “+” chomping indicator. In this case, the final line break
+  * and any trailing empty lines are considered to be part of the scalar’s content. These additional
+  * lines are not subject to folding.
+  */
 sealed abstract class BlockChompingIndicator(indicator: Char) {
   def removeBlankLinesAtEnd(scalar: String): String
 }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/Token.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/Token.scala
@@ -8,7 +8,7 @@ import org.virtuslab.yaml.internal.load.TagValue
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 
 final case class Token(kind: TokenKind, range: Range) {
-  def start: Position = range.start
+  def start: Position       = range.start
   def end: Option[Position] = range.end
 }
 

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/Token.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/Token.scala
@@ -1,12 +1,16 @@
 package org.virtuslab.yaml.internal.load.reader.token
 
+import org.virtuslab.yaml.Position
 import org.virtuslab.yaml.Range
 import org.virtuslab.yaml.internal.load.TagHandle
 import org.virtuslab.yaml.internal.load.TagPrefix
 import org.virtuslab.yaml.internal.load.TagValue
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 
-final case class Token(kind: TokenKind, range: Range)
+final case class Token(kind: TokenKind, range: Range) {
+  def start: Position = range.start
+  def end: Option[Position] = range.end
+}
 
 sealed abstract class TokenKind
 object TokenKind {

--- a/core/shared/src/test/scala/org/virtuslab/yaml/BaseYamlSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/BaseYamlSuite.scala
@@ -7,7 +7,7 @@ import scala.util.Try
 import org.virtuslab.yaml.YamlError
 import org.virtuslab.yaml.internal.load.parse.EventKind
 import org.virtuslab.yaml.internal.load.parse.ParserImpl
-import org.virtuslab.yaml.internal.load.reader.Scanner
+import org.virtuslab.yaml.internal.load.reader.Tokenizer
 import org.virtuslab.yaml.internal.load.reader.token.TokenKind
 
 trait BaseYamlSuite extends munit.FunSuite {
@@ -23,16 +23,16 @@ trait BaseYamlSuite extends munit.FunSuite {
 
   implicit class StringOps(val yaml: String) {
     def events: Either[YamlError, List[EventKind]] = {
-      val reader = new Scanner(yaml)
-      ParserImpl(reader).getEvents().map(_.map(_.kind))
+      val tokenizer = Tokenizer.make(yaml)
+      ParserImpl(tokenizer).getEvents().map(_.map(_.kind))
     }
 
     def tokens: Either[YamlError, List[TokenKind]] = {
-      val reader = new Scanner(yaml)
+      val tokenizer = Tokenizer.make(yaml)
       def loop(tokens: List[TokenKind]): Either[YamlError, List[TokenKind]] =
-        reader.peekToken().flatMap { t =>
+        tokenizer.peekToken().flatMap { t =>
           if (t.kind == TokenKind.StreamEnd) Right(tokens.toList)
-          else loop(tokens :+ reader.popToken().kind)
+          else loop(tokens :+ tokenizer.popToken().kind)
         }
 
       loop(Nil)

--- a/core/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TagSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TagSuite.scala
@@ -4,7 +4,6 @@ package tokenizer
 import org.virtuslab.yaml.internal.load.TagHandle
 import org.virtuslab.yaml.internal.load.TagPrefix
 import org.virtuslab.yaml.internal.load.TagValue
-import org.virtuslab.yaml.internal.load.reader.Scanner
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 import org.virtuslab.yaml.internal.load.reader.token.TokenKind
 import org.virtuslab.yaml.internal.load.reader.token.TokenKind._

--- a/core/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TokenizerSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/tokenizer/TokenizerSuite.scala
@@ -1,7 +1,6 @@
 package org.virtuslab.yaml
 package tokenizer
 
-import org.virtuslab.yaml.internal.load.reader.Scanner
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 import org.virtuslab.yaml.internal.load.reader.token.TokenKind
 import org.virtuslab.yaml.internal.load.reader.token.TokenKind._

--- a/core/shared/src/test/scala/org/virtuslab/yaml/traverse/NodeVisitorSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/traverse/NodeVisitorSuite.scala
@@ -1,7 +1,7 @@
 package org.virtuslab.yaml.traverse
 
-import org.virtuslab.yaml._
 import org.virtuslab.yaml.TestOps._
+import org.virtuslab.yaml._
 
 class NodeVisitorSuite extends munit.FunSuite {
 

--- a/integration-tests/src/main/scala/org/virtuslab/yaml/TestRunner.scala
+++ b/integration-tests/src/main/scala/org/virtuslab/yaml/TestRunner.scala
@@ -12,15 +12,15 @@ import org.virtuslab.yaml.internal.load.parse.EventKind
 import org.virtuslab.yaml.internal.load.parse.EventKind._
 import org.virtuslab.yaml.internal.load.parse.NodeEventMetadata
 import org.virtuslab.yaml.internal.load.parse.ParserImpl
-import org.virtuslab.yaml.internal.load.reader.Scanner
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
+import org.virtuslab.yaml.internal.load.reader.Tokenizer
 
 trait TestRunner {
   def inYaml: String
   def expectedEvents: String
 
   def run(): RunnerResult = {
-    val reader = new Scanner(inYaml)
+    val reader = Tokenizer.make(inYaml)
     val parser = ParserImpl(reader)
     val acc    = new mutable.ArrayDeque[EventKind]()
 


### PR DESCRIPTION
Main change - return [null character](https://www.ascii-code.com/0) instead of None in reader and tokenizer. I'm planning to make tokenizer less magical (well, other parts of code too) and I found wrapping with Some more difficult to comprehend than just operating on plain chars