### PR TITLE
Issue #220 - do not convert quoted strings into other primitive types

### DIFF
--- a/core/shared/src/main/scala/org/virtuslab/yaml/Tag.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/Tag.scala
@@ -1,5 +1,8 @@
 package org.virtuslab.yaml
 
+import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
+import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle.{DoubleQuoted, SingleQuoted}
+
 import scala.reflect.ClassTag
 
 sealed trait Tag {
@@ -35,9 +38,11 @@ object Tag {
   private val minusInfinity  = "-(\\.inf|\\.Inf|\\.INF)".r
   private val plusInfinity   = "\\+?(\\.inf|\\.Inf|\\.INF)".r
 
-  def resolveTag(value: String): Tag = {
+  def resolveTag(value: String, style: Option[ScalarStyle] = None): Tag = {
+    val assumeString = style.exists(s => s == DoubleQuoted || s == SingleQuoted)
     value match {
       case null               => nullTag
+      case _ if assumeString  => str
       case nullPattern(_*)    => nullTag
       case booleanPattern(_*) => boolean
       case int10Pattern(_*)   => int

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
@@ -47,7 +47,7 @@ object ComposerImpl extends Composer {
         case EventKind.MappingStart(NodeEventMetadata(anchor, _)) =>
           composeMappingNode(tail, anchor, aliases)
         case s: EventKind.Scalar =>
-          val tag: Tag = s.metadata.tag.getOrElse(Tag.resolveTag(s.value))
+          val tag: Tag = s.metadata.tag.getOrElse(Tag.resolveTag(s.value, Some(s.style)))
           val node     = Node.ScalarNode(s.value, tag, head.pos)
           s.metadata.anchor.foreach(anchor => aliases.put(anchor, node))
           Right(Result(node, tail))

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/ScalarSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/ScalarSuite.scala
@@ -458,4 +458,54 @@ class ScalarSpec extends BaseYamlSuite {
     )
     assertEquals(yaml.events, Right(expectedEvents))
   }
+  test("quoted integer and bool values") {
+    val yaml =
+      """
+        | -  "123"
+        | -  "bool"
+        | -  'bool'
+        | -  "0xFFFF"
+        | -  123
+        | -  bool
+        | -  0xFFFF
+        |    """.stripMargin
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      SequenceStart(),
+      Scalar("123", ScalarStyle.DoubleQuoted),
+      Scalar("bool", ScalarStyle.DoubleQuoted),
+      Scalar("bool", ScalarStyle.SingleQuoted),
+      Scalar("0xFFFF", ScalarStyle.DoubleQuoted),
+      Scalar("123", ScalarStyle.Plain),
+      Scalar("bool", ScalarStyle.Plain),
+      Scalar("0xFFFF", ScalarStyle.Plain),
+      SequenceEnd,
+      DocumentEnd(),
+      StreamEnd
+    )
+    assertEquals(yaml.events, Right(expectedEvents))
+  }
+
+  test("quoted values are read as String type") {
+    import org.virtuslab.yaml.{StringOps ⇒ SO, _}
+    val isStringType: Seq[Boolean] = Seq(
+      """ "123" """,
+      """ "0xFFFF" """,
+      """ "true" """,
+      """ "null" """,
+      """ "123.456" """,
+      """ "-.inf" """,
+      """ '123' """,
+      """ '0xFFFF' """,
+      """ 'true' """,
+      """ 'null' """,
+      """ '123.456' """,
+      """ '-.inf' """
+    ).map { yaml =>
+      val obj = SO(yaml).as[Any].toOption.get
+      obj.isInstanceOf[java.lang.String]
+    }
+    assertEquals(isStringType, Seq.fill(isStringType.length)(true))
+  }
 }

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -3,6 +3,7 @@ package parser
 
 import org.virtuslab.yaml.internal.load.parse.EventKind._
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
+import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle.DoubleQuoted
 
 class SequenceSuite extends BaseYamlSuite {
 
@@ -328,5 +329,34 @@ class SequenceSuite extends BaseYamlSuite {
       StreamEnd
     )
     assertEquals(yaml.events, Right(expectedEvents))
+  }
+
+  test("quoted integer and bool values") {
+    val yaml =
+      """
+        | -  "123"
+        | -  "bool"
+    """.stripMargin
+    val expectedEvents = List(
+      StreamStart,
+      DocumentStart(),
+      SequenceStart(),
+      Scalar("123", DoubleQuoted),
+      Scalar("bool", DoubleQuoted),
+      SequenceEnd,
+      DocumentEnd(),
+      StreamEnd
+    )
+    assertEquals(yaml.events, Right(expectedEvents))
+  }
+
+  test("quoted integer and bool values are read as String type") {
+    import org.virtuslab.yaml.{StringOps ⇒ SO, _}
+    val yaml1 = """ "123" """
+    val obj1 = SO(yaml1).as[Any].toOption.get
+    assert(obj1.isInstanceOf[java.lang.String])
+    val yaml2 = """ "true" """
+    val obj2 = SO(yaml2).as[Any].toOption.get
+    assert(obj2.isInstanceOf[java.lang.String])
   }
 }

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -330,49 +330,4 @@ class SequenceSuite extends BaseYamlSuite {
     )
     assertEquals(yaml.events, Right(expectedEvents))
   }
-
-  test("quoted integer and bool values") {
-    val yaml =
-      """
-        | -  "123"
-        | -  "bool"
-        | -  'bool'
-        | -  "0xFFFF"
-    """.stripMargin
-    val expectedEvents = List(
-      StreamStart,
-      DocumentStart(),
-      SequenceStart(),
-      Scalar("123", DoubleQuoted),
-      Scalar("bool", DoubleQuoted),
-      Scalar("bool", SingleQuoted),
-      Scalar("0xFFFF", DoubleQuoted),
-      SequenceEnd,
-      DocumentEnd(),
-      StreamEnd
-    )
-    assertEquals(yaml.events, Right(expectedEvents))
-  }
-
-  test("quoted values are read as String type") {
-    import org.virtuslab.yaml.{StringOps ⇒ SO, _}
-    val isStringType: Seq[Boolean] = Seq(
-      """ "123" """,
-      """ "0xFFFF" """, // TODO #222: Cannot parse 0xFFFF as Int.
-      """ "true" """,
-      """ "null" """,
-      """ "123.456" """,
-      """ "-.inf" """, // TODO #222: Cannot parse -.inf as Double.
-      """ '123' """,
-      """ '0xFFFF' """, // TODO #222: Cannot parse 0xFFFF as Int.
-      """ 'true' """,
-      """ 'null' """,
-      """ '123.456' """,
-      """ '-.inf' """
-    ).map { yaml =>
-      val obj = SO(yaml).as[Any].toOption.get
-      obj.isInstanceOf[java.lang.String]
-    }
-    assertEquals(isStringType, Seq.fill(isStringType.length)(true))
-  }
 }

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -3,7 +3,7 @@ package parser
 
 import org.virtuslab.yaml.internal.load.parse.EventKind._
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
-import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle.DoubleQuoted
+import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle.{DoubleQuoted, SingleQuoted}
 
 class SequenceSuite extends BaseYamlSuite {
 
@@ -336,6 +336,7 @@ class SequenceSuite extends BaseYamlSuite {
       """
         | -  "123"
         | -  "bool"
+        | -  'bool'
         | -  "0xFFFF"
     """.stripMargin
     val expectedEvents = List(
@@ -344,6 +345,7 @@ class SequenceSuite extends BaseYamlSuite {
       SequenceStart(),
       Scalar("123", DoubleQuoted),
       Scalar("bool", DoubleQuoted),
+      Scalar("bool", SingleQuoted),
       Scalar("0xFFFF", DoubleQuoted),
       SequenceEnd,
       DocumentEnd(),
@@ -360,7 +362,13 @@ class SequenceSuite extends BaseYamlSuite {
       """ "true" """,
       """ "null" """,
       """ "123.456" """,
-      """ "-.inf" """ // TODO #222: Cannot parse -.inf as Double.
+      """ "-.inf" """, // TODO #222: Cannot parse -.inf as Double.
+      """ '123' """,
+      """ '0xFFFF' """, // TODO #222: Cannot parse 0xFFFF as Int.
+      """ 'true' """,
+      """ 'null' """,
+      """ '123.456' """,
+      """ '-.inf' """
     ).map { yaml =>
       val obj = SO(yaml).as[Any].toOption.get
       obj.isInstanceOf[java.lang.String]

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -356,11 +356,11 @@ class SequenceSuite extends BaseYamlSuite {
     import org.virtuslab.yaml.{StringOps ⇒ SO, _}
     val isStringType = Seq(
       """ "123" """,
-//      """ "0xFFFF" """, // TODO: Cannot parse 0xFFFF as Int?
+      """ "0xFFFF" """, // TODO: Cannot parse 0xFFFF as Int?
       """ "true" """,
       """ "null" """,
-      """ "123.456" """
-//      """ "-.inf" """, // TODO: Cannot parse -.inf as Double?
+      """ "123.456" """,
+      """ "-.inf" """, // TODO: Cannot parse -.inf as Double?
     ).map { yaml =>
       println(yaml, SO(yaml).as[Any])
       val obj = SO(yaml).as[Any].toOption.get

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -3,7 +3,6 @@ package parser
 
 import org.virtuslab.yaml.internal.load.parse.EventKind._
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
-import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle.{DoubleQuoted, SingleQuoted}
 
 class SequenceSuite extends BaseYamlSuite {
 

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -336,6 +336,7 @@ class SequenceSuite extends BaseYamlSuite {
       """
         | -  "123"
         | -  "bool"
+        | -  "0xFFFF"
     """.stripMargin
     val expectedEvents = List(
       StreamStart,
@@ -343,6 +344,7 @@ class SequenceSuite extends BaseYamlSuite {
       SequenceStart(),
       Scalar("123", DoubleQuoted),
       Scalar("bool", DoubleQuoted),
+      Scalar("0xFFFF", DoubleQuoted),
       SequenceEnd,
       DocumentEnd(),
       StreamEnd
@@ -350,13 +352,20 @@ class SequenceSuite extends BaseYamlSuite {
     assertEquals(yaml.events, Right(expectedEvents))
   }
 
-  test("quoted integer and bool values are read as String type") {
+  test("quoted values are read as String type") {
     import org.virtuslab.yaml.{StringOps ⇒ SO, _}
-    val yaml1 = """ "123" """
-    val obj1 = SO(yaml1).as[Any].toOption.get
-    assert(obj1.isInstanceOf[java.lang.String])
-    val yaml2 = """ "true" """
-    val obj2 = SO(yaml2).as[Any].toOption.get
-    assert(obj2.isInstanceOf[java.lang.String])
+    val isStringType = Seq(
+      """ "123" """,
+//      """ "0xFFFF" """, // TODO: Cannot parse 0xFFFF as Int?
+      """ "true" """,
+      """ "null" """,
+      """ "123.456" """,
+//      """ "-.inf" """, // TODO: Cannot parse -.inf as Double?
+    ).map { yaml =>
+      println(yaml, SO(yaml).as[Any])
+      val obj = SO(yaml).as[Any].toOption.get
+      obj.isInstanceOf[java.lang.String]
+    }
+    assertEquals(isStringType, Seq.fill(isStringType.length)(true))
   }
 }

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -356,13 +356,12 @@ class SequenceSuite extends BaseYamlSuite {
     import org.virtuslab.yaml.{StringOps ⇒ SO, _}
     val isStringType = Seq(
       """ "123" """,
-      """ "0xFFFF" """, // TODO: Cannot parse 0xFFFF as Int?
+      """ "0xFFFF" """, // TODO #222: Cannot parse 0xFFFF as Int.
       """ "true" """,
       """ "null" """,
       """ "123.456" """,
-      """ "-.inf" """, // TODO: Cannot parse -.inf as Double?
+      """ "-.inf" """ // TODO #222: Cannot parse -.inf as Double.
     ).map { yaml =>
-      println(yaml, SO(yaml).as[Any])
       val obj = SO(yaml).as[Any].toOption.get
       obj.isInstanceOf[java.lang.String]
     }

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -354,7 +354,7 @@ class SequenceSuite extends BaseYamlSuite {
 
   test("quoted values are read as String type") {
     import org.virtuslab.yaml.{StringOps ⇒ SO, _}
-    val isStringType = Seq(
+    val isStringType: Seq[Boolean] = Seq(
       """ "123" """,
       """ "0xFFFF" """, // TODO #222: Cannot parse 0xFFFF as Int.
       """ "true" """,

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/SequenceSuite.scala
@@ -359,7 +359,7 @@ class SequenceSuite extends BaseYamlSuite {
 //      """ "0xFFFF" """, // TODO: Cannot parse 0xFFFF as Int?
       """ "true" """,
       """ "null" """,
-      """ "123.456" """,
+      """ "123.456" """
 //      """ "-.inf" """, // TODO: Cannot parse -.inf as Double?
     ).map { yaml =>
       println(yaml, SO(yaml).as[Any])


### PR DESCRIPTION
Yaml values of the form `"bool"` or `"123"` or other quoted strings will not be interpreted as `java.lang.Boolean` or `java.lang.Integer`.

This fixes Issue #220 