### PR TITLE
Improve YamlError ADT

### DIFF
--- a/core/shared/src/main/scala-3/org/virtuslab/yaml/YamlDecoderCrossCompat.scala
+++ b/core/shared/src/main/scala-3/org/virtuslab/yaml/YamlDecoderCrossCompat.scala
@@ -19,7 +19,7 @@ private[yaml] trait DecoderMacros {
       .map { (k, v) =>
         k match {
           case ScalarNode(scalarKey, _) => Right((scalarKey, v))
-          case _ => Left(ConstructError(s"Parameter of a class must be a scalar value"))
+          case _ => Left(ConstructError.from(s"Parameter of a class must be a scalar value"))
         }
       }
     val (error, valuesSeq) = keyValueMap.partitionMap(identity)
@@ -40,7 +40,7 @@ private[yaml] trait DecoderMacros {
         case Some(value) => c.construct(value)
         case None =>
           if (isOptional) Right(None)
-          else Left(ConstructError(s"Key $label doesn't exist in parsed document"))
+          else Left(ConstructError.from(s"Key $label doesn't exist in parsed document"))
     }
     val (left, right) = values.partitionMap(identity)
     if left.nonEmpty then Left(left.head)
@@ -68,7 +68,7 @@ private[yaml] trait DecoderMacros {
               )
             } yield (constructedValues)
           case _ =>
-            Left(ConstructError(s"Expected MappingNode, got ${node.getClass.getSimpleName}"))
+            Left(ConstructError.from(s"Expected MappingNode, got ${node.getClass.getSimpleName}"))
     }
 
   protected inline def sumOf[T](s: Mirror.SumOf[T]) =
@@ -80,7 +80,7 @@ private[yaml] trait DecoderMacros {
         .from(instances)
         .map(c => c.construct(node))
         .collectFirst { case r @ Right(_) => r }
-        .getOrElse(Left(ConstructError(s"Cannot parse $node")))
+        .getOrElse(Left(ConstructError.from(s"Cannot parse $node")))
 
   protected inline def summonSumOf[T <: Tuple]: List[YamlDecoder[_]] = inline erasedValue[T] match
     case _: (t *: ts) =>

--- a/core/shared/src/main/scala/org/virtuslab/yaml/YamlDecoder.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/YamlDecoder.scala
@@ -70,9 +70,11 @@ object YamlDecoder extends YamlDecoderCompanionCrossCompat {
         if (pf.isDefinedAt(node)) pf(node)
         else
           Left(
-            ConstructError(s"""|Could't construct ${classTag.runtimeClass.getName} from ${node.tag}
-                               |${node.pos.map(_.errorMsg).getOrElse("")}
-                               |""".stripMargin)
+            ConstructError.from(
+              s"""|Could't construct ${classTag.runtimeClass.getName} from ${node.tag}
+                  |${node.pos.map(_.errorMsg).getOrElse("")}
+                  |""".stripMargin
+            )
           )
     }
 
@@ -160,7 +162,7 @@ object YamlDecoder extends YamlDecoderCompanionCrossCompat {
           case Some(decoder) => decoder.construct(node)
           case None =>
             Left(
-              ConstructError(
+              ConstructError.from(
                 s"""|Could't construct runtime instance of ${node.tag}
                     |${node.pos.map(_.errorMsg).getOrElse("")}
                     |If you're using custom datatype consider using yaml.as[MyType] instead of Any

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
@@ -456,7 +456,7 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
                     else CustomTag(tagValue)
                   parseNodeAttributes(in.peekToken(), metadata.withTag(tag))
                 case None =>
-                  Left(ParseError(s"There is no registered tag directive for handle $handleKey"))
+                  Left(ParseError.NoRegisteredTagDirective(handleKey, token))
               }
           }
         case _ => Right(metadata, token)

--- a/core/shared/src/test/scala-3/org/virtuslab/yaml/ConstructSuite.scala
+++ b/core/shared/src/test/scala-3/org/virtuslab/yaml/ConstructSuite.scala
@@ -42,7 +42,7 @@ class ConstructSuite extends munit.FunSuite:
     )
 
     val expectedConstructError =
-      Left(ConstructError(s"Parameter of a class must be a scalar value"))
+      Left(ConstructError.from(s"Parameter of a class must be a scalar value"))
     assertEquals(node.as[DummyClass], expectedConstructError)
   }
 

--- a/core/shared/src/test/scala-3/org/virtuslab/yaml/ConstructSuite.scala
+++ b/core/shared/src/test/scala-3/org/virtuslab/yaml/ConstructSuite.scala
@@ -42,7 +42,12 @@ class ConstructSuite extends munit.FunSuite:
     )
 
     val expectedConstructError =
-      Left(ConstructError.from(s"Parameter of a class must be a scalar value"))
+      Left(
+        ConstructError.from(
+          s"Parameter of a class must be a scalar value",
+          MappingNode("key" -> "value")
+        )
+      )
     assertEquals(node.as[DummyClass], expectedConstructError)
   }
 

--- a/core/shared/src/test/scala/org/virtuslab/yaml/BaseYamlSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/BaseYamlSuite.scala
@@ -38,6 +38,8 @@ trait BaseYamlSuite extends munit.FunSuite {
       loop(Nil)
     }
 
+    def asNode: Either[YamlError, Node] = new org.virtuslab.yaml.StringOps(yaml).asNode
+
     def debugTokens: Unit = pprint.pprintln(tokens)
   }
 

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/ParserSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/ParserSuite.scala
@@ -3,6 +3,8 @@ package parser
 
 import org.virtuslab.yaml.internal.load.parse.EventKind._
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
+import org.virtuslab.yaml.internal.load.reader.token.Token
+import org.virtuslab.yaml.internal.load.reader.token.TokenKind.MappingKey
 
 class ParserSuite extends BaseYamlSuite {
 
@@ -88,5 +90,37 @@ class ParserSuite extends BaseYamlSuite {
     )
 
     assertEquals(yaml.events, Right(expectedEvents))
+  }
+
+  test("Parsing error") {
+    val errorMessage = """Expected 
+                         |BlockEnd but instead got MappingKey
+                         |  -- zipcode: 12-345
+                         |             ^""".stripMargin
+
+    val yaml =
+      """name: John Wick
+        |age: 40
+        |address:
+        |  - city: Anywhere
+        |  -- zipcode: 12-345
+        |""".stripMargin
+
+    val yamlLines = yaml.split("\n", -1).toVector
+
+    assertEquals(
+      yaml.asNode,
+      Left(
+        ParseError.ExpectedTokenKind(
+          "BlockEnd",
+          Token(
+            MappingKey,
+            Range(Position(65, 4, 13), yamlLines, None)
+          )
+        )
+      )
+    )
+
+    assertEquals(yaml.asNode.left.map(_.msg), Left(errorMessage))
   }
 }


### PR DESCRIPTION
By providing the `ParseError`, `ConstructError` and `ScannerError` the original information that caused the error, an end user can use it for better diagnostics down the line.

Supersedes #271 