### PR TITLE
fixed issue 281 but is this correct?

### DIFF
--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/ScalarStyle.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/ScalarStyle.scala
@@ -11,6 +11,7 @@ object ScalarStyle {
   def escapeSpecialCharacter(scalar: String, scalarStyle: ScalarStyle): String =
     scalarStyle match {
       case ScalarStyle.DoubleQuoted => scalar
+      case ScalarStyle.Literal      => scalar
       case _ =>
         scalar.flatMap { char =>
           char match {

--- a/core/shared/src/test/scala-3/org/virtuslab/yaml/decoder/DecoderSuite.scala
+++ b/core/shared/src/test/scala-3/org/virtuslab/yaml/decoder/DecoderSuite.scala
@@ -363,10 +363,10 @@ class DecoderSuite extends munit.FunSuite:
   test("issue 281 - parse multiline string") {
     case class Data(description: String) derives YamlCodec
 
-    val yaml = """|description: |
-                  |Hi
-                  |my name
-                  |is John""".stripMargin
+    val yaml = """|description: |-
+                  |  Hi
+                  |  my name
+                  |  is John""".stripMargin
 
     val expectedStr = """Hi
                         |my name

--- a/core/shared/src/test/scala-3/org/virtuslab/yaml/decoder/DecoderSuite.scala
+++ b/core/shared/src/test/scala-3/org/virtuslab/yaml/decoder/DecoderSuite.scala
@@ -1,6 +1,6 @@
 package org.virtuslab.yaml.decoder
 
-import org.virtuslab.yaml.Node.ScalarNode
+import org.virtuslab.yaml.Node.*
 import org.virtuslab.yaml.*
 
 class DecoderSuite extends munit.FunSuite:
@@ -358,4 +358,23 @@ class DecoderSuite extends munit.FunSuite:
          |""".stripMargin.as[List[Option[Foo]]]
 
     assertEquals(foo, Right(List(Some(Foo(1, "1")), None)))
+  }
+
+  test("issue 281 - parse multiline string") {
+    case class Data(description: String) derives YamlCodec
+
+    val yaml = """|description: |
+                  |Hi
+                  |my name
+                  |is John""".stripMargin
+
+    val expectedStr = """Hi
+                        |my name
+                        |is John""".stripMargin
+
+    yaml.as[Data] match
+      case Left(error: YamlError) =>
+        fail(s"failed with YamlError: $error")
+      case Right(data) =>
+        assertEquals(data.description, expectedStr)
   }

--- a/core/shared/src/test/scala/org/virtuslab/yaml/parser/ScalarSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/parser/ScalarSuite.scala
@@ -361,7 +361,7 @@ class ScalarSpec extends BaseYamlSuite {
       Scalar("command"),
       SequenceStart(),
       Scalar("bash"),
-      Scalar("# The \\nCRARG\\n# We\\n", ScalarStyle.Literal),
+      Scalar("# The \nCRARG\n# We\n", ScalarStyle.Literal),
       SequenceEnd,
       MappingEnd,
       DocumentEnd(),
@@ -386,7 +386,7 @@ class ScalarSpec extends BaseYamlSuite {
       MappingStart(),
       Scalar("certificate", ScalarStyle.Plain),
       Scalar(
-        "-----BEGIN CERTIFICATE-----\\n0MTk0MVoXDenkKThvP7IS9q\\n+Dzv5hG392KWh5f8xJNs4LbZyl901MeReiLrPH3w=\\n-----END CERTIFICATE----",
+        "-----BEGIN CERTIFICATE-----\n0MTk0MVoXDenkKThvP7IS9q\n+Dzv5hG392KWh5f8xJNs4LbZyl901MeReiLrPH3w=\n-----END CERTIFICATE----",
         ScalarStyle.Literal
       ),
       Scalar("kind", ScalarStyle.Plain),
@@ -416,7 +416,7 @@ class ScalarSpec extends BaseYamlSuite {
       MappingStart(),
       Scalar("certificate", ScalarStyle.Plain),
       Scalar(
-        "-----BEGIN CERTIFICATE-----\\n0MTk0MVoXDenkKThvP7IS9q\\n+Dzv5hG392KWh5f8xJNs4LbZyl901MeReiLrPH3w=\\n-----END CERTIFICATE----\\n\\n\\n",
+        "-----BEGIN CERTIFICATE-----\n0MTk0MVoXDenkKThvP7IS9q\n+Dzv5hG392KWh5f8xJNs4LbZyl901MeReiLrPH3w=\n-----END CERTIFICATE----\n\n\n",
         ScalarStyle.Literal
       ),
       Scalar("kind", ScalarStyle.Plain),
@@ -445,11 +445,11 @@ class ScalarSpec extends BaseYamlSuite {
       SequenceStart(),
       MappingStart(),
       Scalar("content"),
-      Scalar("[Unit]\\n", ScalarStyle.Literal),
+      Scalar("[Unit]\n", ScalarStyle.Literal),
       MappingEnd,
       MappingStart(),
       Scalar("content"),
-      Scalar("set -x\\n", ScalarStyle.Literal),
+      Scalar("set -x\n", ScalarStyle.Literal),
       MappingEnd,
       SequenceEnd,
       MappingEnd,


### PR DESCRIPTION
This change fixes #281 buuuut there's a bunch of tests that fail now, like:

```
=> Diff (- obtained, + expected)
     Scalar(
-      value = """# The ∙
-CRARG
-# We
-""",
+      value = "# The \\nCRARG\\n# We\\n",
       style = Literal(),
```

```
=> Diff (- obtained, + expected)
     Scalar(
-      value = """-----BEGIN CERTIFICATE-----
-0MTk0MVoXDenkKThvP7IS9q
-+Dzv5hG392KWh5f8xJNs4LbZyl901MeReiLrPH3w=
------END CERTIFICATE----""",
+      value = "-----BEGIN CERTIFICATE-----\\n0MTk0MVoXDenkKThvP7IS9q\\n+Dzv5hG392KWh5f8xJNs4LbZyl901MeReiLrPH3w=\\n-----END CERTIFICATE----",
       style = Literal(),
```

So apparently tests were written **with** the assumption that newlines will end up transformed to escaped newlines: `\n`. I don't think this is correct and I think the author of #281 is correct that we should not tamper with strings and provide them as they are for literals. 