### PR TITLE
fix: decode non-finite floats as Any

### DIFF
--- a/core/shared/src/main/scala/org/virtuslab/yaml/YamlDecoder.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/YamlDecoder.scala
@@ -120,10 +120,14 @@ object YamlDecoder extends YamlDecoderCompanionCrossCompat {
     }
   }
 
+  private def isNonFiniteFloat(value: String): Boolean =
+    Tag.nan.matches(value) || Tag.plusInfinity.matches(value) || Tag.minusInfinity.matches(value)
+
   def forDoublePrecise: YamlDecoder[Double] = YamlDecoder { case s @ ScalarNode(value, _) =>
     forDouble.construct(s).flatMap { n =>
       val ns = n.toString
-      if (ns == value) Right(n) else Left(ConstructError.from(s"Double, decoded $ns", s))
+      if (ns == value || isNonFiniteFloat(value)) Right(n)
+      else Left(ConstructError.from(s"Double, decoded $ns", s))
     }
   }
 
@@ -143,7 +147,8 @@ object YamlDecoder extends YamlDecoderCompanionCrossCompat {
   def forFloatPrecise: YamlDecoder[Float] = YamlDecoder { case s @ ScalarNode(value, _) =>
     forFloat.construct(s).flatMap { n =>
       val ns = n.toString
-      if (ns == value) Right(n) else Left(ConstructError.from(s"Float, decoded $ns", s))
+      if (ns == value || isNonFiniteFloat(value)) Right(n)
+      else Left(ConstructError.from(s"Float, decoded $ns", s))
     }
   }
 

--- a/core/shared/src/test/scala-3/org/virtuslab/yaml/decoder/DecoderSuite.scala
+++ b/core/shared/src/test/scala-3/org/virtuslab/yaml/decoder/DecoderSuite.scala
@@ -487,6 +487,30 @@ class DecoderSuite extends munit.FunSuite:
         assertEquals(value, Map("value" -> 0.018256052173961423))
   }
 
+  test("decode non-finite floats as Any") {
+    val yaml = "values: [.inf, -.Inf, +.INF, .NAN, .nan, .NaN]"
+
+    yaml.as[Any] match
+      case Left(error: YamlError) =>
+        fail(s"failed with YamlError: $error")
+      case Right(value) =>
+        val values = value.asInstanceOf[Map[String, List[Any]]]("values")
+        val expected = List(
+          Float.PositiveInfinity,
+          Float.NegativeInfinity,
+          Float.PositiveInfinity,
+          Float.NaN,
+          Float.NaN,
+          Float.NaN
+        )
+        values.zipAll(expected, 0f, 0f).foreach {
+          case (actual: Float, expected) =>
+            assertEqualsFloat(actual, expected, 0f)
+          case (actual, _) =>
+            fail(s"Expected Float, got ${actual.getClass.getName}: $actual")
+        }
+  }
+
   test("issue 120 - fail conversion of !!null to non-optional types") {
     case class Foo(key1: Int, key2: Int) derives YamlDecoder
 


### PR DESCRIPTION
## Motivation

`YamlDecoder[Any]` rejects YAML non-finite float scalars such as `.inf`, `-.Inf`, `+.INF`, `.NAN`, `.nan`, and `.NaN`, even though direct `Float` and `Double` decoding already accepts these spellings.

The `Any` path uses the precise Float/Double decoders before falling back to `BigDecimal`. For non-finite scalars, the numeric value is parsed successfully, but `toString` returns `Infinity`, `-Infinity`, or `NaN`, which does not match the original YAML spelling. The precise decoder rejects it and `BigDecimal` then fails.

Related history: #330 fixed direct Float/Double NaN/Inf tag handling, but did not cover this `Any` precision path.

Closes #477.

## Modification

- Add a small helper that recognizes the YAML non-finite float spellings already accepted by `Tag`.
- Let `forFloatPrecise` and `forDoublePrecise` accept those non-finite spellings after successful numeric decoding.
- Add a regression test for `yaml.as[Any]` with non-finite float scalars.

## Result

`yaml.as[Any]` now decodes non-finite float scalars consistently with direct `Float`/`Double` decoding. Invalid values such as `-XXXinf` are still rejected because they do not match the existing `Tag` patterns.

Local validation:

- `sbt 'core/testOnly org.virtuslab.yaml.decoder.DecoderSuite'`
- `sbt core/test`
- `sbt coreJS/test`
- `sbt coreNative/test`
- `sbt '++2.13.18' core/test coreJS/test coreNative/test`
- `sbt scalafmtCheckAll`
- `git diff --check`

## Risk

Low. The change only affects values that already match the YAML non-finite float tag patterns and already decode successfully through the direct Float/Double decoders. Finite precise decoding and invalid non-finite-like strings keep the existing behavior.
