### PR TITLE
Fix identity hash leaking into composer error message for unresolved aliases

### DIFF
--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
@@ -89,7 +89,7 @@ object ComposerImpl extends Composer {
           aliases.get(a.id) match {
             case Some(node) => node
             case None =>
-              throw ComposerException(ComposerError(s"There is no anchor for ${a.id} alias"))
+              throw ComposerException(ComposerError(s"There is no anchor for ${a.id.anchor} alias"))
           }
         case _: EventKind.StreamStart.type | _: EventKind.DocumentStart =>
           composeNode(ctx, aliases)

--- a/core/shared/src/test/scala/org/virtuslab/yaml/ComposerSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/ComposerSuite.scala
@@ -6,6 +6,7 @@ import org.virtuslab.yaml.internal.load.compose.ComposerImpl
 import org.virtuslab.yaml.internal.load.parse.Anchor
 import org.virtuslab.yaml.internal.load.parse.Event
 import org.virtuslab.yaml.internal.load.parse.EventKind._
+import org.virtuslab.yaml.internal.load.parse.NodeEventMetadata
 import org.virtuslab.yaml.syntax.YamlPrimitive._
 
 /** Examples taken from https://yaml.org/spec/1.2/spec.html#id2759963
@@ -198,6 +199,28 @@ class ComposerSuite extends munit.FunSuite {
     assertEquals(
       ComposerImpl.fromEvents(events),
       Left(ComposerError("There is no anchor for missing alias"))
+    )
+  }
+
+  test("alias nested inside its own anchor reports the anchor name") {
+    // `a: &x [*x]` - a collection's anchor is registered only after its children
+    // are composed, so the nested alias finds no registered anchor yet.
+    val events = List(
+      StreamStart,
+      DocumentStart(),
+      MappingStart(),
+      Scalar("a"),
+      SequenceStart(NodeEventMetadata(Anchor("x"))),
+      Alias(Anchor("x")),
+      SequenceEnd,
+      MappingEnd,
+      DocumentEnd(),
+      StreamEnd
+    ).map(Event(_, None))
+
+    assertEquals(
+      ComposerImpl.fromEvents(events),
+      Left(ComposerError("There is no anchor for x alias"))
     )
   }
 }

--- a/core/shared/src/test/scala/org/virtuslab/yaml/ComposerSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/ComposerSuite.scala
@@ -3,6 +3,7 @@ package org.virtuslab.yaml
 import org.virtuslab.yaml.Node
 import org.virtuslab.yaml.Node._
 import org.virtuslab.yaml.internal.load.compose.ComposerImpl
+import org.virtuslab.yaml.internal.load.parse.Anchor
 import org.virtuslab.yaml.internal.load.parse.Event
 import org.virtuslab.yaml.internal.load.parse.EventKind._
 import org.virtuslab.yaml.syntax.YamlPrimitive._
@@ -183,5 +184,20 @@ class ComposerSuite extends munit.FunSuite {
     )
 
     assertEquals(ComposerImpl.multipleFromEvents(events), expected)
+  }
+
+  test("alias without a matching anchor reports the anchor name") {
+    val events = List(
+      StreamStart,
+      DocumentStart(),
+      Alias(Anchor("missing")),
+      DocumentEnd(),
+      StreamEnd
+    ).map(Event(_, None))
+
+    assertEquals(
+      ComposerImpl.fromEvents(events),
+      Left(ComposerError("There is no anchor for missing alias"))
+    )
   }
 }

--- a/core/shared/src/test/scala/org/virtuslab/yaml/decoder/AliasErrorSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/decoder/AliasErrorSuite.scala
@@ -1,0 +1,20 @@
+package org.virtuslab.yaml.decoder
+
+import org.virtuslab.yaml._
+
+class AliasErrorSuite extends BaseDecoderErrorSuite {
+
+  test("alias referencing an undefined anchor reports the anchor name") {
+    assertError(
+      "foo: *missing".as[Map[String, String]],
+      "There is no anchor for missing alias"
+    )
+  }
+
+  test("cyclic alias reports the anchor name") {
+    assertError(
+      "a: &x [*x]".as[Map[String, String]],
+      "There is no anchor for x alias"
+    )
+  }
+}


### PR DESCRIPTION
Fixes #365

The composer error for an alias without a registered anchor interpolated the `Anchor` value itself:

```scala
s"There is no anchor for ${a.id} alias"
```

`Event.Anchor` is a `class Anchor(val anchor: String) extends AnyVal` without a `toString`, so the default `Object.toString` leaks into the message:

```
Left(There is no anchor for org.virtuslab.yaml.internal.load.parse.Anchor@3fbe8166 alias)
```

## Change

Interpolate the anchor name (`a.id.anchor`), keeping the message prefix unchanged:

```
Left(There is no anchor for missing alias)
```

The prefix is kept stable because downstream consumers match on it (e.g. sjsonnet normalizes this message for its `std.parseYaml` error output via `startsWith("There is no anchor for")` — databricks/sjsonnet#1110).

This error path is hit both by undefined/forward aliases (the repro in #365) and by cyclic aliases such as `a: &x [*x]` — collection anchors are registered only after their children are composed, so the inner alias finds no registered anchor. The name is useful in both cases (`There is no anchor for x alias`).

The change is confined to an error-message string in the `internal` package: no public API or binary-compatibility impact.

## Tests

- `ComposerSuite`: event-level tests asserting the exact `ComposerError` message for an alias with no matching anchor, and for an alias nested inside its own anchor (the cyclic case).
- New `AliasErrorSuite` (in the shared, cross Scala 2/3 test sources): public-API tests mirroring the #365 repro (`foo: *missing`) and the cyclic case (`a: &x [*x]`), asserting deterministic messages.

Verified with `sbt +core/test` on both Scala 3.3.8 and 2.13.18, `sbt coreJS/Test/compile coreNative/Test/compile`, and `sbt scalafmtCheckAll`.
