### PR TITLE
Render tag value instead of Tag wrapper in construct error message

### DIFF
--- a/core/shared/src/main/scala/org/virtuslab/yaml/YamlDecoder.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/YamlDecoder.scala
@@ -217,10 +217,10 @@ object YamlDecoder extends YamlDecoderCompanionCrossCompat {
           case None =>
             Left(
               ConstructError.from(
-                s"""|Could't construct runtime instance of ${node.tag}
+                s"""|Could't construct runtime instance of ${node.tag.value}
                     |${node.pos.map(_.errorMsg).getOrElse("")}
                     |If you're using custom datatype consider using yaml.as[MyType] instead of Any
-                    |Or define LoadSettings where you'll specify how to construct ${node.tag}
+                    |Or define LoadSettings where you'll specify how to construct ${node.tag.value}
                     |""".stripMargin
               )
             )

--- a/core/shared/src/test/scala/org/virtuslab/yaml/decoder/AnyConstructErrorSuite.scala
+++ b/core/shared/src/test/scala/org/virtuslab/yaml/decoder/AnyConstructErrorSuite.scala
@@ -1,0 +1,20 @@
+package org.virtuslab.yaml.decoder
+
+import org.virtuslab.yaml._
+
+class AnyConstructErrorSuite extends BaseDecoderErrorSuite {
+
+  test("construct error renders the tag value instead of the Tag wrapper") {
+    val yaml = "!foo bar"
+
+    yaml.as[Any] match {
+      case Left(error: YamlError) =>
+        assert(
+          error.msg.contains("Could't construct runtime instance of !foo"),
+          s"unexpected message: ${error.msg}"
+        )
+        assert(!error.msg.contains("CustomTag("), s"tag wrapper leaked: ${error.msg}")
+      case r @ Right(_) => fail(s"Get $r, expected Left")
+    }
+  }
+}


### PR DESCRIPTION
Same family as #365 (interpolated value leaks its wrapper into an error message), different site and deterministic — split out as its own PR.

`YamlDecoder.forAny`'s fallback constructs its error with `${node.tag}`:

```scala
s"""|Could't construct runtime instance of ${node.tag}
    ...
    |Or define LoadSettings where you'll specify how to construct ${node.tag}
```

`Tag` is a sealed trait of case classes (`CoreSchemaTag(value)` / `CustomTag(value)`), so the case-class wrapper leaks into the message:

```
Could't construct runtime instance of CustomTag(!foo)
...
Or define LoadSettings where you'll specify how to construct CustomTag(!foo)
```

## Change

Interpolate `${node.tag.value}` (the trait exposes `def value: String`):

```
Could't construct runtime instance of !foo
...
Or define LoadSettings where you'll specify how to construct !foo
```

This is consistent with the other error sites in the same file (lines 73 and 82 already use `${node.tag.value}`); the two sites changed here were the exceptions.

## Test

New shared (cross Scala 2/3) `AnyConstructErrorSuite`: `"!foo bar".as[Any]` reaches the construct fallback and the test asserts the message contains the tag value (`!foo`) and not the wrapper (`CustomTag(`).

## Verification

- `sbt core/test` and `sbt ++2.13.18 core/test` — pass
- `sbt scalafmtCheckAll` — clean

Message-only change in an error string; no API or binary-compatibility impact.
