### PR TITLE
More efficient parsing and serialization

### DIFF
--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/dump/present/PresenterImpl.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/dump/present/PresenterImpl.scala
@@ -28,11 +28,11 @@ object PresenterImpl extends Presenter {
             tail
           case _: MappingStart =>
             insertSequencePadding()
-            pushAndIncreaseIndent(MappingStart())
+            pushAndIncreaseIndent(new MappingStart())
             serializeMapping(tail)
           case _: SequenceStart =>
             insertSequencePadding()
-            pushAndIncreaseIndent(SequenceStart())
+            pushAndIncreaseIndent(new SequenceStart())
             serializeSequence(tail)
           case _ => serializeNode(tail)
         }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/dump/serialize/SerializerImpl.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/dump/serialize/SerializerImpl.scala
@@ -11,31 +11,33 @@ import scala.collection.immutable.ArraySeq
 object SerializerImpl extends Serializer {
   override def toEvents(node: Node): Seq[EventKind] = {
     val builder = ArraySeq.newBuilder[EventKind]
-    builder.addOne(DocumentStart())
+    builder.addOne(DocumentStart)
     convertNode(node, builder)
-    builder.addOne(DocumentEnd())
-    builder.result()
+    builder.addOne(DocumentEnd).result()
   }
 
   private def convertNode(node: Node, builder: Builder[EventKind, Seq[EventKind]]): Unit =
-    node match {
+    builder.addOne(node match {
       case scalar: Node.ScalarNode =>
-        builder.addOne(new Scalar(scalar.value, metadata = NodeEventMetadata(tag = scalar.tag)))
+        new Scalar(scalar.value, metadata = new NodeEventMetadata(tag = new Some(scalar.tag)))
       case mapping: Node.MappingNode =>
-        builder.addOne(MappingStart())
+        builder.addOne(MappingStart)
         val it = mapping.mappings.iterator
         while (it.hasNext) {
           val kv = it.next()
           convertNode(kv._1, builder)
           convertNode(kv._2, builder)
         }
-        builder.addOne(MappingEnd)
+        MappingEnd
       case sequence: Node.SequenceNode =>
-        builder.addOne(SequenceStart())
+        builder.addOne(SequenceStart)
         val it = sequence.nodes.iterator
-        while (it.hasNext) {
-          convertNode(it.next(), builder)
-        }
-        builder.addOne(SequenceEnd)
-    }
+        while (it.hasNext) convertNode(it.next(), builder)
+        SequenceEnd
+    })
+
+  private val MappingStart  = new MappingStart()
+  private val SequenceStart = new SequenceStart()
+  private val DocumentStart = new DocumentStart()
+  private val DocumentEnd   = new DocumentEnd()
 }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
@@ -3,8 +3,6 @@ package org.virtuslab.yaml.internal.load.compose
 import scala.annotation.tailrec
 import scala.collection.mutable
 import scala.collection.immutable.ListMap
-import scala.util.control.NoStackTrace
-
 import org.virtuslab.yaml.ComposerError
 import org.virtuslab.yaml.Node
 import org.virtuslab.yaml.Range
@@ -26,23 +24,19 @@ trait Composer {
 
 object ComposerImpl extends Composer {
   // A lightweight mutable wrapper avoiding `Result` allocation per event.
-  private class Context(var events: List[Event])
+  private class Context(var events: List[Event], val aliases: java.util.HashMap[Anchor, Node])
 
-  // Internal exception used to fast-fail without paying the stack-trace generation cost
-  private case class ComposerException(err: YamlError) extends RuntimeException with NoStackTrace
-
-  override def fromEvents(events: List[Event]): Either[YamlError, Node] = events match {
-    case Nil => new Left(ComposerError("No events available"))
-    case _ =>
-      try new Right(composeNode(new Context(events), mutable.Map.empty))
+  override def fromEvents(events: List[Event]): Either[YamlError, Node] =
+    if (events eq Nil) new Left(new ComposerError("No events available"))
+    else {
+      try new Right(composeNode(new Context(events, new java.util.HashMap)))
       catch {
-        case ComposerException(err) => new Left(err)
+        case err: ComposerError => new Left(err)
       }
-  }
+    }
 
   override def multipleFromEvents(events: List[Event]): Either[YamlError, List[Node]] = {
-    val aliases = mutable.Map.empty[Anchor, Node]
-    val ctx     = new Context(events)
+    val ctx = new Context(events, new java.util.HashMap)
 
     @tailrec
     def go(out: mutable.ListBuffer[Node]): List[Node] =
@@ -56,117 +50,110 @@ object ComposerImpl extends Composer {
               ctx.events = tail
               go(out)
             case _ =>
-              out.addOne(composeNode(ctx, aliases))
-              go(out)
+              go(out.addOne(composeNode(ctx)))
           }
-        case Nil => out.toList
+        case _ => out.toList
       }
 
     try new Right(go(new mutable.ListBuffer[Node]))
     catch {
-      case ComposerException(err) => new Left(err)
+      case err: ComposerError => new Left(err)
     }
   }
 
+  @tailrec
   private def composeNode(
-      ctx: Context,
-      aliases: mutable.Map[Anchor, Node]
+      ctx: Context
   ): Node = ctx.events match {
     case head :: tail =>
       // Advance the pointer so that recursive calls see the remaining sequence
       ctx.events = tail
       head.kind match {
         case s: EventKind.Scalar =>
-          val tag: Tag = s.metadata.tag.getOrElse(Tag.resolveTag(s.value, Some(s.style)))
-          val node     = new Node.ScalarNode(s.value, tag, head.pos)
-          s.metadata.anchor.foreach(anchor => aliases.put(anchor, node))
+          val tag = s.metadata.tag match {
+            case Some(t) => t
+            case _       => Tag.resolveTag(s.value, new Some(s.style))
+          }
+          val node = new Node.ScalarNode(s.value, tag, head.pos)
+          s.metadata.anchor match {
+            case Some(a) => ctx.aliases.put(a, node)
+            case _       =>
+          }
           node
         case ss: EventKind.SequenceStart =>
-          composeSequenceNode(ctx, ss.metadata.anchor, aliases)
+          composeSequenceNode(ctx, ss.metadata.anchor)
         case ms: EventKind.MappingStart =>
-          composeMappingNode(ctx, ms.metadata.anchor, aliases)
+          composeMappingNode(ctx, ms.metadata.anchor)
         case a: EventKind.Alias =>
-          aliases.get(a.id) match {
-            case Some(node) => node
-            case None =>
-              throw ComposerException(ComposerError(s"There is no anchor for ${a.id} alias"))
-          }
+          val node = ctx.aliases.get(a.id)
+          if (node eq null) throw new ComposerError(s"There is no anchor for ${a.id} alias")
+          node
         case _: EventKind.StreamStart.type | _: EventKind.DocumentStart =>
-          composeNode(ctx, aliases)
-        case event =>
-          throw ComposerException(ComposerError(s"Expected YAML node, but found: $event"))
+          composeNode(ctx)
+        case event => throw new ComposerError(s"Expected YAML node, but found: $event")
       }
-    case Nil => throw ComposerException(ComposerError("No events available"))
+    case _ => throw new ComposerError("No events available")
   }
 
   private def composeSequenceNode(
       ctx: Context,
-      anchorOpt: Option[Anchor],
-      aliases: mutable.Map[Anchor, Node]
+      anchorOpt: Option[Anchor]
   ): Node.SequenceNode = {
 
     @tailrec
-    def parseChildren(
+    def go(
         children: mutable.ListBuffer[Node],
-        firstChildPos: Option[Range] = None
-    ): Node.SequenceNode = {
-      ctx.events match {
-        case e :: tail =>
-          e.kind match {
-            case _: EventKind.SequenceEnd.type =>
-              ctx.events = tail
-              val sequence = new Node.SequenceNode(children.toList, Tag.seq, firstChildPos)
-              if (anchorOpt.isDefined) aliases.put(anchorOpt.get, sequence)
-              sequence
-            case _ =>
-              val node = composeNode(ctx, aliases)
-              children.addOne(node)
-              val nextPos =
-                if (firstChildPos.isEmpty) node.pos
-                else firstChildPos
-              parseChildren(children, nextPos)
-          }
-        case Nil =>
-          throw ComposerException(ComposerError("Not found SequenceEnd event for sequence"))
-      }
+        firstChildPos: Option[Range]
+    ): Node.SequenceNode = ctx.events match {
+      case e :: tail =>
+        e.kind match {
+          case _: EventKind.SequenceEnd.type =>
+            ctx.events = tail
+            val sequence = new Node.SequenceNode(children.toList, Tag.seq, firstChildPos)
+            if (anchorOpt.isDefined) ctx.aliases.put(anchorOpt.get, sequence)
+            sequence
+          case _ =>
+            val node = composeNode(ctx)
+            val nextPos =
+              if (firstChildPos eq None) node.pos
+              else firstChildPos
+            go(children.addOne(node), nextPos)
+        }
+      case _ =>
+        throw new ComposerError("Not found SequenceEnd event for sequence")
     }
 
-    parseChildren(new mutable.ListBuffer[Node]())
+    go(new mutable.ListBuffer[Node], None)
   }
 
   private def composeMappingNode(
       ctx: Context,
-      anchorOpt: Option[Anchor],
-      aliases: mutable.Map[Anchor, Node]
+      anchorOpt: Option[Anchor]
   ): Node.MappingNode = {
 
     @tailrec
-    def parseMappings(
-        mappingsBuffer: mutable.ArrayBuffer[(Node, Node)],
-        firstChildPos: Option[Range] = None
+    def go(
+        mappings: mutable.Builder[(Node, Node), ListMap[Node, Node]],
+        firstChildPos: Option[Range]
     ): Node.MappingNode = ctx.events match {
       case e :: tail =>
         e.kind match {
           case _: EventKind.MappingEnd.type =>
             ctx.events = tail
-            val mapping =
-              new Node.MappingNode(ListMap.from(mappingsBuffer), Tag.map, firstChildPos)
-            if (anchorOpt.isDefined) aliases.put(anchorOpt.get, mapping)
+            val mapping = new Node.MappingNode(mappings.result(), Tag.map, firstChildPos)
+            if (anchorOpt.isDefined) ctx.aliases.put(anchorOpt.get, mapping)
             mapping
           case _: EventKind.StreamStart.type | _: EventKind.StreamEnd.type |
               _: EventKind.DocumentStart | _: EventKind.DocumentEnd =>
-            throw ComposerException(
-              ComposerError(s"Invalid event, got: ${e.kind}, expected Node")
-            )
+            throw new ComposerError(s"Invalid event, got: ${e.kind}, expected Node")
           case _ =>
-            val keyNode   = composeNode(ctx, aliases)
-            val valueNode = composeNode(ctx, aliases)
-            mappingsBuffer.addOne((keyNode, valueNode))
-            parseMappings(mappingsBuffer, keyNode.pos)
+            val keyNode   = composeNode(ctx)
+            val valueNode = composeNode(ctx)
+            go(mappings.addOne((keyNode, valueNode)), keyNode.pos)
         }
-      case Nil => throw ComposerException(ComposerError("Not found MappingEnd event for mapping"))
+      case _ => throw new ComposerError("Not found MappingEnd event for mapping")
     }
 
-    parseMappings(new mutable.ArrayBuffer[(Node, Node)])
+    go(ListMap.newBuilder[Node, Node], None)
   }
 }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/compose/Composer.scala
@@ -24,19 +24,27 @@ trait Composer {
 
 object ComposerImpl extends Composer {
   // A lightweight mutable wrapper avoiding `Result` allocation per event.
-  private class Context(var events: List[Event], val aliases: java.util.HashMap[Anchor, Node])
+  private class Context(
+      var events: List[Event],
+      private[this] var aliases: java.util.HashMap[Anchor, Node] = null
+  ) {
+    def getAliases: java.util.HashMap[Anchor, Node] = {
+      if (aliases eq null) aliases = new java.util.HashMap[Anchor, Node]
+      aliases
+    }
+  }
 
   override def fromEvents(events: List[Event]): Either[YamlError, Node] =
     if (events eq Nil) new Left(new ComposerError("No events available"))
     else {
-      try new Right(composeNode(new Context(events, new java.util.HashMap)))
+      try new Right(composeNode(new Context(events)))
       catch {
         case err: ComposerError => new Left(err)
       }
     }
 
   override def multipleFromEvents(events: List[Event]): Either[YamlError, List[Node]] = {
-    val ctx = new Context(events, new java.util.HashMap)
+    val ctx = new Context(events)
 
     @tailrec
     def go(out: mutable.ListBuffer[Node]): List[Node] =
@@ -76,7 +84,7 @@ object ComposerImpl extends Composer {
           }
           val node = new Node.ScalarNode(s.value, tag, head.pos)
           s.metadata.anchor match {
-            case Some(a) => ctx.aliases.put(a, node)
+            case Some(a) => ctx.getAliases.put(a, node)
             case _       =>
           }
           node
@@ -85,7 +93,7 @@ object ComposerImpl extends Composer {
         case ms: EventKind.MappingStart =>
           composeMappingNode(ctx, ms.metadata.anchor)
         case a: EventKind.Alias =>
-          val node = ctx.aliases.get(a.id)
+          val node = ctx.getAliases.get(a.id)
           if (node eq null) throw new ComposerError(s"There is no anchor for ${a.id} alias")
           node
         case _: EventKind.StreamStart.type | _: EventKind.DocumentStart =>
@@ -106,18 +114,17 @@ object ComposerImpl extends Composer {
         firstChildPos: Option[Range]
     ): Node.SequenceNode = ctx.events match {
       case e :: tail =>
-        e.kind match {
-          case _: EventKind.SequenceEnd.type =>
-            ctx.events = tail
-            val sequence = new Node.SequenceNode(children.toList, Tag.seq, firstChildPos)
-            if (anchorOpt.isDefined) ctx.aliases.put(anchorOpt.get, sequence)
-            sequence
-          case _ =>
-            val node = composeNode(ctx)
-            val nextPos =
-              if (firstChildPos eq None) node.pos
-              else firstChildPos
-            go(children.addOne(node), nextPos)
+        if (e.kind eq EventKind.SequenceEnd) {
+          ctx.events = tail
+          val sequence = new Node.SequenceNode(children.result(), Tag.seq, firstChildPos)
+          if (anchorOpt.isDefined) ctx.getAliases.put(anchorOpt.get, sequence)
+          sequence
+        } else {
+          val node = composeNode(ctx)
+          val nextPos =
+            if (firstChildPos eq None) node.pos
+            else firstChildPos
+          go(children.addOne(node), nextPos)
         }
       case _ =>
         throw new ComposerError("Not found SequenceEnd event for sequence")
@@ -137,19 +144,14 @@ object ComposerImpl extends Composer {
         firstChildPos: Option[Range]
     ): Node.MappingNode = ctx.events match {
       case e :: tail =>
-        e.kind match {
-          case _: EventKind.MappingEnd.type =>
-            ctx.events = tail
-            val mapping = new Node.MappingNode(mappings.result(), Tag.map, firstChildPos)
-            if (anchorOpt.isDefined) ctx.aliases.put(anchorOpt.get, mapping)
-            mapping
-          case _: EventKind.StreamStart.type | _: EventKind.StreamEnd.type |
-              _: EventKind.DocumentStart | _: EventKind.DocumentEnd =>
-            throw new ComposerError(s"Invalid event, got: ${e.kind}, expected Node")
-          case _ =>
-            val keyNode   = composeNode(ctx)
-            val valueNode = composeNode(ctx)
-            go(mappings.addOne((keyNode, valueNode)), keyNode.pos)
+        if (e.kind eq EventKind.MappingEnd) {
+          ctx.events = tail
+          val mapping = new Node.MappingNode(mappings.result(), Tag.map, firstChildPos)
+          if (anchorOpt.isDefined) ctx.getAliases.put(anchorOpt.get, mapping)
+          mapping
+        } else {
+          val keyNode = composeNode(ctx)
+          go(mappings.addOne((keyNode, composeNode(ctx))), keyNode.pos)
         }
       case _ => throw new ComposerError("Not found MappingEnd event for mapping")
     }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/Event.scala
@@ -21,7 +21,7 @@ object Event {
   val streamStart = Event(StreamStart, None)
   val streamEnd   = Event(StreamEnd, None)
 
-  def apply(kind: EventKind, pos: Range): Event = Event(kind, new Some(pos))
+  def apply(kind: EventKind, pos: Range): Event = new Event(kind, new Some(pos))
 }
 
 sealed abstract class EventKind
@@ -55,16 +55,16 @@ final case class NodeEventMetadata(
     anchor: Option[Anchor] = None,
     tag: Option[Tag] = None
 ) {
-  def withAnchor(anchor: Anchor) = this.copy(anchor = Some(anchor))
-  def withTag(tag: Tag)          = this.copy(tag = Some(tag))
+  def withAnchor(anchor: Anchor) = this.copy(anchor = new Some(anchor))
+  def withTag(tag: Tag)          = this.copy(tag = new Some(tag))
 }
 
 object NodeEventMetadata {
-  final val empty                              = NodeEventMetadata()
-  def apply(anchor: Anchor): NodeEventMetadata = NodeEventMetadata(anchor = Some(anchor))
+  final val empty                              = new NodeEventMetadata()
+  def apply(anchor: Anchor): NodeEventMetadata = new NodeEventMetadata(anchor = new Some(anchor))
   def apply(anchor: Anchor, tag: Tag): NodeEventMetadata =
-    NodeEventMetadata(anchor = Some(anchor), tag = Some(tag))
-  def apply(tag: Tag): NodeEventMetadata = NodeEventMetadata(tag = Some(tag))
+    new NodeEventMetadata(anchor = Some(anchor), tag = Some(tag))
+  def apply(tag: Tag): NodeEventMetadata = new NodeEventMetadata(tag = new Some(tag))
 }
 
 class Anchor(val anchor: String) extends AnyVal

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
@@ -366,28 +366,28 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
         in.popToken()
         productions.prepend(ParseMappingEnd)
         productions.prepend(ParseMappingEntry)
-        Event(EventKind.MappingStart(metadata), nextToken.range)
+        Event(new EventKind.MappingStart(metadata), nextToken.range)
       case _: TokenKind.SequenceStart.type if couldParseBlockCollection =>
         in.popToken()
         productions.prepend(ParseSequenceEnd)
         productions.prepend(ParseSequenceEntry)
-        Event(EventKind.SequenceStart(metadata), nextToken.range)
+        Event(new EventKind.SequenceStart(metadata), nextToken.range)
       case _: TokenKind.FlowMappingStart.type =>
         in.popToken()
         productions.prepend(ParseFlowMappingEnd)
         productions.prepend(ParseFlowMappingEntryOpt)
-        Event(EventKind.MappingStart(metadata), nextToken.range)
+        Event(new EventKind.MappingStart(metadata), nextToken.range)
       case _: TokenKind.FlowSequenceStart.type =>
         in.popToken()
         productions.prepend(ParseFlowSeqEnd)
         productions.prepend(ParseFlowSeqEntryOpt)
-        Event(EventKind.SequenceStart(metadata), nextToken.range)
+        Event(new EventKind.SequenceStart(metadata), nextToken.range)
       case s: TokenKind.Scalar =>
         in.popToken()
-        Event(EventKind.Scalar(s.value, s.scalarStyle, metadata), nextToken.range)
+        Event(new EventKind.Scalar(s.value, s.scalarStyle, metadata), nextToken.range)
       case _ =>
         Event(
-          EventKind.Scalar("", ScalarStyle.Plain, metadata.withTag(Tag.nullTag)),
+          new EventKind.Scalar("", ScalarStyle.Plain, metadata.withTag(Tag.nullTag)),
           nextToken.range
         )
     }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/parse/ParserImpl.scala
@@ -129,16 +129,14 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
   }
 
   private def parseStreamStart(token: Token) = {
-    productions.prepend(ParseStreamEnd)
-    productions.prepend(ParseDocumentStartOpt)
+    productions.prepend(ParseStreamEnd).prepend(ParseDocumentStartOpt)
     Event(EventKind.StreamStart, token.range)
   }
 
   private def parseDocumentStart(token: Token) = {
-    productions.prepend(ParseDocumentEnd)
-    productions.prepend(ParseNode)
+    productions.prepend(ParseDocumentEnd).prepend(ParseNode)
     Event(
-      EventKind.DocumentStart(explicit = {
+      new EventKind.DocumentStart(explicit = {
         (token.kind eq TokenKind.DocumentStart) && {
           in.popToken()
           true
@@ -155,13 +153,11 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
         in.popToken()
         productions.prepend(ParseDocumentStartOpt) // call self once again
       case _: TokenKind.DocumentStart.type =>
-        productions.prepend(ParseDocumentStartOpt)
-        productions.prepend(ParseDocumentStart)
+        productions.prepend(ParseDocumentStartOpt).prepend(ParseDocumentStart)
       case _: TokenKind.MappingStart.type | _: TokenKind.Scalar | _: TokenKind.SequenceStart.type |
           _: TokenKind.FlowMappingStart.type | _: TokenKind.FlowSequenceStart.type |
           _: TokenKind.Anchor | _: TokenKind.Tag =>
-        productions.prepend(ParseDocumentStartOpt)
-        productions.prepend(ParseDocumentStart)
+        productions.prepend(ParseDocumentStartOpt).prepend(ParseDocumentStart)
       case _ =>
     }
     getNextEventImpl()
@@ -189,9 +185,7 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
   private def parseMappingEntry(token: Token) =
     if (token.kind eq TokenKind.MappingKey) {
       in.popToken()
-      productions.prepend(ParseMappingEntryOpt)
-      productions.prepend(ParseMappingValue)
-      productions.prepend(ParseScalar)
+      productions.prepend(ParseMappingEntryOpt).prepend(ParseMappingValue).prepend(ParseScalar)
       getNextEventImpl()
     } else throw ParseError.from(TokenKind.MappingKey, token)
 
@@ -204,9 +198,8 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
 
   private def parseMappingValueNode(token: Token) =
     if (token.kind eq TokenKind.SequenceValue) {
-      productions.prepend(ParseMappingSequenceEnd)
-      productions.prepend(ParseSequenceEntry)
-      Event(EventKind.SequenceStart(), token.range)
+      productions.prepend(ParseMappingSequenceEnd).prepend(ParseSequenceEntry)
+      Event(new EventKind.SequenceStart(), token.range)
     } else parseNode(token)
 
   private def parseMappingSequenceEnd(token: Token) =
@@ -226,8 +219,7 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
   private def parseSequenceEntry(token: Token) =
     if (token.kind eq TokenKind.SequenceValue) {
       in.popToken()
-      productions.prepend(ParseSequenceEntryOpt)
-      productions.prepend(ParseNode)
+      productions.prepend(ParseSequenceEntryOpt).prepend(ParseNode)
       getNextEventImpl()
     } else throw ParseError.from(TokenKind.SequenceValue, token)
 
@@ -245,9 +237,7 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
   private def parseFlowMappingEntry(token: Token) = {
     if (token.kind eq TokenKind.MappingKey) {
       in.popToken()
-      productions.prepend(ParseFlowMappingComma)
-      productions.prepend(ParseMappingValue)
-      productions.prepend(ParseScalar)
+      productions.prepend(ParseFlowMappingComma).prepend(ParseMappingValue).prepend(ParseScalar)
     }
     getNextEventImpl()
   }
@@ -255,9 +245,10 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
   private def parseFlowMappingEntryOpt(token: Token) =
     token.kind match {
       case _: TokenKind.Scalar | _: TokenKind.Anchor =>
-        productions.prepend(ParseFlowMappingEntry)
-        productions.prepend(ParseFlowMappingComma)
-        productions.prepend(ParseFlowNode)
+        productions
+          .prepend(ParseFlowMappingEntry)
+          .prepend(ParseFlowMappingComma)
+          .prepend(ParseFlowNode)
         parseFlowNode(token)
       case k =>
         if (k eq TokenKind.MappingKey) { // flow mapping start right after flow mapping start{>>{
@@ -289,7 +280,7 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
     productions.prepend(ParseFlowSeqComma)
     if (token.kind eq TokenKind.MappingKey) {
       productions.prepend(ParseFlowSeqPairKey)
-      Event(EventKind.MappingStart(), token.range)
+      Event(new EventKind.MappingStart(), token.range)
     } else {
       productions.prepend(ParseFlowNode)
       getNextEventImpl()
@@ -310,9 +301,10 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
   private def parseFlowPairKey(token: Token) =
     if (token.kind eq TokenKind.MappingKey) {
       in.popToken()
-      productions.prepend(ReturnEvent(t => Event(EventKind.MappingEnd, t.range)))
-      productions.prepend(ParseFlowSeqPairValue)
-      productions.prepend(ParseFlowNode)
+      productions
+        .prepend(new ReturnEvent(t => Event(EventKind.MappingEnd, t.range)))
+        .prepend(ParseFlowSeqPairValue)
+        .prepend(ParseFlowNode)
       getNextEventImpl()
     } else throw ParseError.from(TokenKind.MappingKey, token)
 
@@ -337,11 +329,11 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
         nextToken.kind match {
           case TokenKind.Scalar(value, style) =>
             in.popToken()
-            Event(EventKind.Scalar(value, style, metadata), token.range)
+            Event(new EventKind.Scalar(value, style, metadata), token.range)
           case TokenKind.Alias(alias) =>
             if (metadata.anchor.isEmpty) {
               in.popToken()
-              Event(EventKind.Alias(Anchor(alias)), nextToken.range)
+              Event(new EventKind.Alias(new Anchor(alias)), nextToken.range)
             } else throw ParseError.from("Alias cannot have an anchor", nextToken)
           case _ =>
             throw ParseError.from(TokenKind.Scalar.toString, token)
@@ -360,27 +352,23 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
       case a: TokenKind.Alias =>
         if (metadata.anchor.isEmpty) {
           in.popToken()
-          Event(EventKind.Alias(Anchor(a.value)), nextToken.range)
+          Event(new EventKind.Alias(new Anchor(a.value)), nextToken.range)
         } else throw ParseError.from("Alias cannot have an anchor", nextToken)
       case _: TokenKind.MappingStart.type if couldParseBlockCollection =>
         in.popToken()
-        productions.prepend(ParseMappingEnd)
-        productions.prepend(ParseMappingEntry)
+        productions.prepend(ParseMappingEnd).prepend(ParseMappingEntry)
         Event(new EventKind.MappingStart(metadata), nextToken.range)
       case _: TokenKind.SequenceStart.type if couldParseBlockCollection =>
         in.popToken()
-        productions.prepend(ParseSequenceEnd)
-        productions.prepend(ParseSequenceEntry)
+        productions.prepend(ParseSequenceEnd).prepend(ParseSequenceEntry)
         Event(new EventKind.SequenceStart(metadata), nextToken.range)
       case _: TokenKind.FlowMappingStart.type =>
         in.popToken()
-        productions.prepend(ParseFlowMappingEnd)
-        productions.prepend(ParseFlowMappingEntryOpt)
+        productions.prepend(ParseFlowMappingEnd).prepend(ParseFlowMappingEntryOpt)
         Event(new EventKind.MappingStart(metadata), nextToken.range)
       case _: TokenKind.FlowSequenceStart.type =>
         in.popToken()
-        productions.prepend(ParseFlowSeqEnd)
-        productions.prepend(ParseFlowSeqEntryOpt)
+        productions.prepend(ParseFlowSeqEnd).prepend(ParseFlowSeqEntryOpt)
         Event(new EventKind.SequenceStart(metadata), nextToken.range)
       case s: TokenKind.Scalar =>
         in.popToken()
@@ -412,7 +400,7 @@ final class ParserImpl private (in: Tokenizer) extends Parser {
           val handleKey = s.handle.value
           directives.get(handleKey) match {
             case Some(prefix) =>
-              val tagValue = prefix + s.rest
+              val tagValue = prefix.concat(s.rest)
               val tag =
                 if (Tag.coreSchemaValues.contains(tagValue)) new CoreSchemaTag(tagValue)
                 else new CustomTag(tagValue)

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
@@ -44,11 +44,11 @@ object Reader {
 }
 
 private[yaml] class StringReader(in: String) extends Reader {
-  private val len = in.length
-  var line: Int   = 0
-  var column: Int = 0
-  var offset: Int = 0
-  val lines       = in.split("\n", -1).toVector
+  private[this] val len = in.length
+  var line: Int         = 0
+  var column: Int       = 0
+  var offset: Int       = 0
+  val lines             = in.split("\n", -1).toVector
 
   override def pos = new Position(offset, line, column)
 

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Reader.scala
@@ -1,13 +1,12 @@
 package org.virtuslab.yaml.internal.load.reader
 
-import scala.annotation.tailrec
 import org.virtuslab.yaml.Position
 import org.virtuslab.yaml.Range
 
 trait Reader {
 
   /** Read current character and advance by 1 position
-    * @return current character or '\u0000' in case there are no chars left
+    * @return current character
     */
   def read(): Char
 
@@ -28,8 +27,8 @@ trait Reader {
   def peekN(n: Int): String
 
   final def peekNext(): Char          = peek(1)
-  final def isWhitespace: Boolean     = peek().isWhitespace
-  final def isNextWhitespace: Boolean = peekNext().isWhitespace
+  final def isWhitespace: Boolean     = Character.isWhitespace(peek(0))
+  final def isNextWhitespace: Boolean = Character.isWhitespace(peek(1))
   final def isNewline: Boolean        = isNewlineN(0)
   final def isNextNewline: Boolean    = isNewlineN(1)
 
@@ -37,7 +36,7 @@ trait Reader {
     val c = peek(n)
     c == '\n' || isWindowsNewline(c)
   }
-  protected def isWindowsNewline(c: Char): Boolean = c == '\r' && peekNext() == '\n'
+  protected def isWindowsNewline(c: Char): Boolean = c == '\r' && peek(1) == '\n'
 }
 
 object Reader {
@@ -51,64 +50,94 @@ private[yaml] class StringReader(in: String) extends Reader {
   var offset: Int = 0
   val lines       = in.split("\n", -1).toVector
 
-  override def pos   = Position(offset, line, column)
-  override def range = Range(pos, lines)
+  override def pos = new Position(offset, line, column)
+
+  override def range = new Range(pos, lines)
 
   override def peek(n: Int = 0): Char = {
     val i = offset + n
     if (i < len) in.charAt(i)
-    else Reader.nullTerminator
+    else '\u0000'
   }
 
   override def peekN(n: Int): String = {
     val end = offset + n
     if (end <= len) in.substring(offset, end)
     else {
-      val available = math.max(0, len - offset)
-      val padding   = new String(Array.fill(n - available)(Reader.nullTerminator))
-      if (available > 0) in.substring(offset, len) + padding
+      val available = Math.max(len - offset, 0)
+      val padding   = new String(new Array[Char](n - available))
+      if (available > 0) in.substring(offset, len).concat(padding)
       else padding
     }
   }
 
-  private def nextLine(): Unit = { column = 0; line += 1 }
-
-  private def skipAndMaintainPosition() = {
-    val char = in.charAt(offset)
-    if (isWindowsNewline(char)) {
-      offset += 2
-      nextLine()
-      2
-    } else if (char == '\n') {
-      offset += 1
-      nextLine()
-      1
-    } else {
-      offset += 1
-      column += 1
-      1
-    }
-  }
-
   override def skipN(n: Int): Unit = {
-    @tailrec def loop(left: Int): Unit =
-      if (left <= 0) ()
-      else {
-        val skipped = skipAndMaintainPosition()
-        loop(left - skipped)
-      }
-    loop(n)
+    val limit = offset + n
+    while (offset < limit) skipCharacter()
   }
 
-  override def skipCharacter(): Unit = skipAndMaintainPosition()
+  override def skipCharacter(): Unit = {
+    var i = offset
+    var c = in.charAt(i)
+    i += 1
+    if (
+      c == '\n' || c == '\r' && {
+        i < len && {
+          c = in.charAt(i)
+          i += 1
+          c == '\n'
+        }
+      }
+    ) {
+      column = 0
+      line += 1
+    } else column += 1
+    offset = i
+  }
 
-  override def skipWhitespaces(): Unit =
-    while (isWhitespace)
-      skipCharacter()
+  override def skipWhitespaces(): Unit = {
+    var i       = offset
+    var c: Char = 0
+    while ({
+      i < len && {
+        c = in.charAt(i)
+        Character.isWhitespace(c)
+      }
+    }) {
+      i += 1
+      if (
+        c == '\n' || c == '\r' && {
+          i < len && {
+            c = in.charAt(i)
+            i += 1
+            c == '\n'
+          }
+        }
+      ) {
+        column = 0
+        line += 1
+      } else column += 1
+    }
+    offset = i
+  }
 
   override def read(): Char = {
-    skipCharacter()
-    in.charAt(offset - 1)
+    var i = offset
+    var c = in.charAt(i)
+    i += 1
+    if (
+      c == '\n' || c == '\r' && {
+        i < len && {
+          c = in.charAt(i)
+          i += 1
+          c == '\n'
+        }
+      }
+    ) {
+      column = 0
+      line += 1
+    } else column += 1
+    offset = i
+    c
   }
-
 }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
@@ -1,6 +1,6 @@
 package org.virtuslab.yaml.internal.load.reader
 
-import scala.annotation.tailrec
+import scala.annotation.{switch, tailrec}
 import org.virtuslab.yaml.Range
 import org.virtuslab.yaml.ScannerError
 import org.virtuslab.yaml.YamlError
@@ -8,11 +8,12 @@ import org.virtuslab.yaml.internal.load.TagHandle
 import org.virtuslab.yaml.internal.load.TagPrefix
 import org.virtuslab.yaml.internal.load.TagValue
 import org.virtuslab.yaml.internal.load.reader.token.BlockChompingIndicator
-import org.virtuslab.yaml.internal.load.reader.token.BlockChompingIndicator._
+import org.virtuslab.yaml.internal.load.reader.token.BlockChompingIndicator.*
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 import org.virtuslab.yaml.internal.load.reader.token.Token
 import org.virtuslab.yaml.internal.load.reader.token.TokenKind
-import org.virtuslab.yaml.internal.load.reader.token.TokenKind._
+import org.virtuslab.yaml.internal.load.reader.token.TokenKind.*
+
 import scala.collection.mutable
 
 trait Tokenizer {
@@ -30,7 +31,7 @@ object Tokenizer {
   def make(str: String): Tokenizer = new StringTokenizer(str)
 }
 
-private class StringTokenizer(str: String) extends Tokenizer {
+private final class StringTokenizer(str: String) extends Tokenizer {
 
   private val ctx = TokenizerContext(str)
   private val in  = ctx.reader
@@ -66,54 +67,26 @@ private class StringTokenizer(str: String) extends Tokenizer {
     val closedBlockTokens = ctx.checkIndents(in.column)
     if (closedBlockTokens.nonEmpty || shouldPopPlainKeys) queue.appendAll(ctx.popPotentialKeys())
     queue.appendAll(closedBlockTokens)
-    val peeked = in.peek()
-    peeked match {
-      case Reader.nullTerminator =>
-        queue.appendAll(ctx.popPotentialKeys())
-        queue.appendAll(ctx.checkIndents(-1))
-        queue.append(Token(StreamEnd, in.range))
-      case '-' if isDocumentStart =>
-        in.skipN(if (in.peek(3) == Reader.nullTerminator) 3 else 4)
-        queue.appendAll(ctx.parseDocumentStart(in.column))
-      case '-' if in.isNextWhitespace =>
-        // when last indent is lesser than current one, it means that this is start of the sequence
-        if (ctx.isInBlockCollection && ctx.indent < in.column) {
-          ctx.addIndent(in.column)
-          queue.append(Token(SequenceStart, in.range))
-        }
-        if (ctx.isInBlockCollection && !ctx.isPlainKeyAllowed) {
-          throw ScannerError.from(in.range, "cannot start sequence")
-        }
-        in.skipCharacter() // skip '-'
-        queue.appendAll(ctx.popPotentialKeys())
-        queue.append(Token(SequenceValue, in.range))
-      case '.' if isDocumentEnd =>
-        in.skipN(if (in.peek(3) == Reader.nullTerminator) 3 else 4)
-        queue.appendAll(ctx.parseDocumentEnd())
+    (in.peek(): @switch) match {
       case '[' =>
         in.skipCharacter()
         ctx.enterFlowSequence
-        queue.appendAll(ctx.popPotentialKeys())
-        queue.append(Token(FlowSequenceStart, in.range))
+        queue.appendAll(ctx.popPotentialKeys()).append(new Token(FlowSequenceStart, in.range))
       case ']' =>
         in.skipCharacter()
         ctx.leaveFlowSequence
-        queue.appendAll(ctx.popPotentialKeys())
-        queue.append(Token(FlowSequenceEnd, in.range))
+        queue.appendAll(ctx.popPotentialKeys()).append(new Token(FlowSequenceEnd, in.range))
       case '{' =>
         in.skipCharacter()
         ctx.enterFlowMapping
         ctx.isPlainKeyAllowed = true
-        queue.appendAll(ctx.popPotentialKeys())
-        queue.append(Token(FlowMappingStart, in.range))
+        queue.appendAll(ctx.popPotentialKeys()).append(new Token(FlowMappingStart, in.range))
       case '}' =>
         in.skipCharacter()
         ctx.leaveFlowMapping
-        queue.appendAll(ctx.popPotentialKeys())
-        queue.append(Token(FlowMappingEnd, in.range))
+        queue.appendAll(ctx.popPotentialKeys()).append(new Token(FlowMappingEnd, in.range))
       case '&' =>
-        val (name, range) = parseAnchorName()
-        val anchorToken   = Token(Anchor(name), range)
+        val anchorToken = parseAnchorToken(false)
         if (ctx.isPlainKeyAllowed) ctx.addPotentialKey(anchorToken)
         else queue.append(anchorToken)
       case '!' =>
@@ -124,27 +97,25 @@ private class StringTokenizer(str: String) extends Tokenizer {
           sb.append('!')
           while ({
             val c = in.peek()
-            c != '>' && !c.isWhitespace
+            c != '>' && !Character.isWhitespace(c)
           }) sb.append(in.read())
-          in.peek() match {
-            case '>' =>
-              sb.append(in.read())
-              sb.toString
-            case _ =>
-              throw ScannerError.from(in.range, "Lacks '>' which closes verbatim tag attribute")
+          if (in.peek() != '>') {
+            throw ScannerError.from(in.range, "Lacks '>' which closes verbatim tag attribute")
           }
+          sb.append(in.read()).toString
         }
 
         def parseTagSuffix(): String = {
           val sb = new java.lang.StringBuilder
           while ({
             val c = in.peek()
-            !(c == '[' || c == ']' || c == '{' || c == '}') && !c.isWhitespace
+            if (c == '[' || c == ']' || c == '{' || c == '}') {
+              throw ScannerError.from(in.range, "Invalid character in tag")
+            } else if (c == '\u0000') {
+              throw ScannerError.from(in.range, "Input stream ended unexpectedly")
+            }
+            !Character.isWhitespace(c)
           }) sb.append(in.read())
-          val c = in.peek()
-          if (c == '[' || c == ']' || c == '{' || c == '}') {
-            throw ScannerError.from(in.range, "Invalid character in tag")
-          }
           try UrlDecoder.decode(sb.toString)
           catch {
             case _: IllegalArgumentException =>
@@ -156,42 +127,42 @@ private class StringTokenizer(str: String) extends Tokenizer {
           second match {
             case '!' => // tag handle starts with '!!'
               in.skipCharacter()
-              TagValue.Shorthand(TagHandle.Secondary, parseTagSuffix())
+              new TagValue.Shorthand(TagHandle.Secondary, parseTagSuffix())
             case _ => // tag handle starts with '!<char>' where char isn't space
               val sb = new java.lang.StringBuilder
               while ({
                 val c = in.peek()
-                !(c == '[' || c == ']' || c == '{' || c == '}') && !c.isWhitespace && c != '!'
+                if (c == '[' || c == ']' || c == '{' || c == '}') {
+                  throw ScannerError.from(in.range, "Invalid character in tag")
+                } else if (c == '\u0000') {
+                  throw ScannerError.from(in.range, "Input stream ended unexpectedly")
+                }
+                !Character.isWhitespace(c) && c != '!'
               }) sb.append(in.read())
-              val c = in.peek()
-              if (c == '[' || c == ']' || c == '{' || c == '}')
-                throw ScannerError.from(in.range, "Invalid character in tag")
               in.peek() match {
                 case '!' =>
                   sb.insert(0, '!')    // prepend already skipped exclamation mark
                   sb.append(in.read()) // append ending exclamation mark
-                  TagValue.Shorthand(TagHandle.Named(sb.toString), parseTagSuffix())
+                  new TagValue.Shorthand(new TagHandle.Named(sb.toString), parseTagSuffix())
                 case ' ' =>
-                  TagValue.Shorthand(TagHandle.Primary, sb.toString)
+                  new TagValue.Shorthand(TagHandle.Primary, sb.toString)
                 case _ => throw ScannerError.from(in.range, "Invalid tag handle")
               }
           }
 
         in.skipCharacter() // skip first '!'
-        val peeked = in.peek()
-        val tag: Tag = peeked match {
-          case Reader.nullTerminator =>
-            throw ScannerError.from(in.range, "Input stream ended unexpectedly")
+        val tag = new Tag(in.peek() match {
           case '<' =>
-            val tag = parseVerbatimTag()
-            Tag(TagValue.Verbatim(tag))
+            new TagValue.Verbatim(parseVerbatimTag())
           case ' ' =>
-            Tag(TagValue.NonSpecific)
-          case char =>
-            val tagValue = parseShorthandTag(char)
-            Tag(tagValue)
-        }
-        val token = Token(tag, range)
+            TagValue.NonSpecific
+          case c =>
+            if (c == '\u0000') {
+              throw ScannerError.from(in.range, "Input stream ended unexpectedly")
+            }
+            parseShorthandTag(c)
+        })
+        val token = new Token(tag, range)
         if (ctx.isPlainKeyAllowed) ctx.addPotentialKey(token)
         else queue.append(token)
       case '%' =>
@@ -204,8 +175,8 @@ private class StringTokenizer(str: String) extends Tokenizer {
           case 'T' if in.peekN(3) == "TAG" =>
             in.skipN(3)
 
-            def parseTagHandle() = {
-              in.peekNext() match { // peeking next char!! current char is exclamation mark
+            def parseTagHandle(): TagHandle =
+              in.peek(1) match { // peeking next char!! current char is exclamation mark
                 case ' ' =>
                   in.skipCharacter() // skip exclamation mark
                   TagHandle.Primary
@@ -215,51 +186,34 @@ private class StringTokenizer(str: String) extends Tokenizer {
                 case _ =>
                   val sb = new java.lang.StringBuilder
                   sb.append(in.read())
-
-                  def condition = {
+                  while ({
                     val c = in.peek()
-                    !c.isWhitespace && c != '!'
-                  }
-
-                  while (condition) {
-                    sb.append(in.read())
-                  }
+                    !Character.isWhitespace(c) && c != '!'
+                  }) sb.append(in.read())
                   sb.append(in.read())
-                  TagHandle.Named(sb.toString)
+                  new TagHandle.Named(sb.toString)
               }
-            }
 
-            def parseTagPrefix() = {
+            def parseTagPrefix(): TagPrefix = {
               skipSpaces()
-              in.peek() match {
-                case '!' =>
-                  val sb = new java.lang.StringBuilder
-                  while (!in.peek().isWhitespace) {
-                    sb.append(in.read())
-                  }
-                  TagPrefix.Local(sb.toString)
-                case char if char != '!' && char != ',' =>
-                  val sb = new java.lang.StringBuilder
-                  while (!in.peek().isWhitespace) {
-                    sb.append(in.read())
-                  }
-                  TagPrefix.Global(sb.toString)
-                case _ => throw ScannerError.from(in.range, "Invalid tag prefix in TAG directive")
+              val c = in.peek()
+              if (c == ',') {
+                throw ScannerError.from(in.range, "Invalid tag prefix in TAG directive")
               }
+              val sb = new java.lang.StringBuilder
+              while (!Character.isWhitespace(in.peek())) sb.append(in.read())
+              val prefix = sb.toString
+              if (c == '!') new TagPrefix.Local(prefix)
+              else new TagPrefix.Global(prefix)
             }
 
             skipSpaces()
-            in.peek() match {
-              case '!' =>
-                val handle = parseTagHandle()
-                val prefix = parseTagPrefix()
-                queue.append(Token(TokenKind.TagDirective(handle, prefix), range))
-              case _ =>
-                throw ScannerError.from(
-                  in.range,
-                  "Tag handle in TAG directive should start with '!'"
-                )
+            if (in.peek() != '!') {
+              throw ScannerError.from(in.range, "Tag handle in TAG directive should start with '!'")
             }
+            queue.append(
+              new Token(new TokenKind.TagDirective(parseTagHandle(), parseTagPrefix()), range)
+            )
           case _ => throw ScannerError.from(in.range, "Unknown directive, expected YAML or TAG")
         }
       case '"' =>
@@ -267,17 +221,17 @@ private class StringTokenizer(str: String) extends Tokenizer {
 
         @tailrec
         def readScalar(): String = in.peek() match {
-          case Reader.nullTerminator =>
-            sb.toString
           case '"' =>
             in.skipCharacter()
             sb.toString
-          case '\\' if in.peekNext() == '"' =>
+          case '\\' if in.peek(1) == '"' =>
             in.skipN(2)
             sb.append('"')
             readScalar()
+          case '\u0000' =>
+            sb.toString
           case c =>
-            if (c == '\n' || c == '\r' && in.peekNext() == '\n') {
+            if (c == '\n' || c == '\r' && in.peek(1) == '\n') {
               skipUntilNextToken()
               sb.append(' ')
               readScalar()
@@ -291,19 +245,17 @@ private class StringTokenizer(str: String) extends Tokenizer {
         val isPlainKeyAllowed = ctx.isPlainKeyAllowed
         val range             = in.range
         in.skipCharacter() // skip double quote
-        val scalar      = readScalar()
-        val endRange    = range.withEndPos(in.pos)
-        val scalarToken = Token(Scalar(scalar, ScalarStyle.DoubleQuoted), endRange)
+        val scalarToken =
+          new Token(Scalar(readScalar(), ScalarStyle.DoubleQuoted), range.withEndPos(in.pos))
         if (isPlainKeyAllowed) ctx.addPotentialKey(scalarToken)
         else queue.append(scalarToken)
       case '\'' =>
         val sb = new java.lang.StringBuilder
 
         @tailrec
-        def readScalar(): String = in.peek() match {
-          case Reader.nullTerminator => sb.toString
+        def readScalar(): String = (in.peek(): @switch) match {
           case '\'' =>
-            if (in.peekNext() == '\'') {
+            if (in.peek(1) == '\'') {
               in.skipN(2)
               sb.append('\'')
               readScalar()
@@ -315,6 +267,7 @@ private class StringTokenizer(str: String) extends Tokenizer {
             sb.append(' ')
             skipUntilNextToken()
             readScalar()
+          case '\u0000' => sb.toString
           case c =>
             in.skipCharacter()
             sb.append(c)
@@ -324,23 +277,23 @@ private class StringTokenizer(str: String) extends Tokenizer {
         val isPlainKeyAllowed = ctx.isPlainKeyAllowed
         val range             = in.range
         in.skipCharacter() // skip single quote
-        val scalar      = readScalar()
-        val endRange    = range.withEndPos(in.pos)
-        val scalarToken = Token(Scalar(scalar, ScalarStyle.SingleQuoted), endRange)
+        val scalarToken =
+          new Token(Scalar(readScalar(), ScalarStyle.SingleQuoted), range.withEndPos(in.pos))
         if (isPlainKeyAllowed) ctx.addPotentialKey(scalarToken)
         else queue.append(scalarToken)
       case '>' =>
         val sb    = new java.lang.StringBuilder
         val range = in.range
         in.skipCharacter() // skip >
-        val indentationIndicator: Option[Int] = parseIndentationIndicator()
-        val chompingIndicator                 = parseChompingIndicator()
-        val indentation =
-          if (indentationIndicator.isEmpty) parseIndentationIndicator()
-          else indentationIndicator
+        var indentation       = parseIndentationIndicator()
+        val chompingIndicator = parseChompingIndicator()
+        if (indentation eq None) indentation = parseIndentationIndicator()
         parseBlockHeader()
-        if (indentation.isEmpty) skipUntilNextToken()
-        val foldedIndent = indentation.getOrElse(in.column)
+        if (indentation eq None) skipUntilNextToken()
+        val foldedIndent = indentation match {
+          case Some(fi) => fi
+          case _        => in.column
+        }
         skipUntilNextIndent(foldedIndent)
 
         @tailrec
@@ -349,7 +302,6 @@ private class StringTokenizer(str: String) extends Tokenizer {
             thisLineIsIndented: Boolean = false
         ): String = {
           in.peek() match {
-            case Reader.nullTerminator => sb.toString
             case _ if in.isNewline =>
               ctx.isPlainKeyAllowed = true
               if (in.isNextNewline) {
@@ -357,43 +309,42 @@ private class StringTokenizer(str: String) extends Tokenizer {
                   in.skipCharacter()
                   sb.append('\n')
                 }
-                if (in.peek() != Reader.nullTerminator) {
+                if (in.peek() != '\u0000') {
                   in.skipCharacter()
                   skipUntilNextIndent(foldedIndent)
                 }
-                if (in.column != foldedIndent || in.peek() == Reader.nullTerminator) {
-                  if (chompingIndicator == BlockChompingIndicator.Keep) sb.append('\n')
+                if (in.column != foldedIndent || in.peek() == '\u0000') {
+                  if (chompingIndicator eq BlockChompingIndicator.Keep) sb.append('\n')
                   sb.toString
                 } else readFolded(prevCharWasNewline = true)
               } else {
                 in.skipCharacter() // skip newline
                 skipUntilNextIndent(foldedIndent)
-                if (in.column != foldedIndent || in.peek() == Reader.nullTerminator) {
+                if (in.column != foldedIndent || in.peek() == '\u0000') {
                   chompingIndicator match {
-                    case Keep => // if keep, strip all trailing newlines and spaces but count them and append counted amount of newlines
-                      var count    = 1
-                      var lastChar = sb.charAt(sb.length - 1)
-                      while (lastChar == '\n' || lastChar == ' ') {
+                    case _: Keep.type => // if keep, strip all trailing newlines and spaces but count them and append counted amount of newlines
+                      var count = 1
+                      while ({
+                        val lastChar = sb.charAt(sb.length - 1)
+                        lastChar == '\n' || lastChar == ' '
+                      }) {
                         sb.deleteCharAt(sb.length - 1)
-                        lastChar = sb.charAt(sb.length - 1)
                         count += 1
                       }
                       while (count > 0) {
                         sb.append('\n')
                         count -= 1
                       }
-                    case Strip => // if strip, strip all trailing newlines and spaces
-                      var lastChar = sb.charAt(sb.length - 1)
-                      while (lastChar == '\n' || lastChar == ' ') {
-                        sb.deleteCharAt(sb.length - 1)
-                        lastChar = sb.charAt(sb.length - 1)
-                      }
-                    case Clip => // if clip, strip all trailing newlines and spaces and append a single newline
-                      var lastChar = sb.charAt(sb.length - 1)
-                      while (lastChar == '\n' || lastChar == ' ') {
-                        sb.deleteCharAt(sb.length - 1)
-                        lastChar = sb.charAt(sb.length - 1)
-                      }
+                    case _: Strip.type => // if strip, strip all trailing newlines and spaces
+                      while ({
+                        val lastChar = sb.charAt(sb.length - 1)
+                        lastChar == '\n' || lastChar == ' '
+                      }) sb.deleteCharAt(sb.length - 1)
+                    case _ => // if clip, strip all trailing newlines and spaces and append a single newline
+                      while ({
+                        val lastChar = sb.charAt(sb.length - 1)
+                        lastChar == '\n' || lastChar == ' '
+                      }) sb.deleteCharAt(sb.length - 1)
                       sb.append('\n')
                   }
                   sb.toString // final result
@@ -411,117 +362,138 @@ private class StringTokenizer(str: String) extends Tokenizer {
               }
               sb.append(in.read())
               readFolded(thisLineIsIndented = true)
+            case '\u0000' => sb.toString
             case _ =>
               sb.append(in.read())
               readFolded(thisLineIsIndented = thisLineIsIndented)
           }
         }
-        val scalar        = readFolded()
-        val chompedScalar = chompingIndicator.removeBlankLinesAtEnd(scalar)
-        queue.append(Token(Scalar(chompedScalar, ScalarStyle.Folded), range))
+
+        val chompedScalar = chompingIndicator.removeBlankLinesAtEnd(readFolded())
+        queue.append(new Token(Scalar(chompedScalar, ScalarStyle.Folded), range))
       case '|' =>
         val sb    = new java.lang.StringBuilder
         val range = in.range
         in.skipCharacter() // skip |
-        val indentationIndicator: Option[Int] = parseIndentationIndicator()
-        val chompingIndicator                 = parseChompingIndicator()
-        val indentation =
-          if (indentationIndicator.isEmpty) parseIndentationIndicator()
-          else indentationIndicator
+        var indentation       = parseIndentationIndicator()
+        val chompingIndicator = parseChompingIndicator()
+        if (indentation eq None) indentation = parseIndentationIndicator()
         parseBlockHeader()
-        if (indentation.isEmpty) skipUntilNextChar()
-        val foldedIndent = indentation.getOrElse(in.column)
+        if (indentation eq None) in.skipWhitespaces()
+        val foldedIndent = indentation match {
+          case Some(fi) => fi
+          case _        => in.column
+        }
         skipUntilNextIndent(foldedIndent)
 
         @tailrec
         def readLiteral(): String =
-          in.peek() match {
-            case Reader.nullTerminator => sb.toString
-            case _ if in.isNewline =>
-              ctx.isPlainKeyAllowed = true
-              sb.append(in.read())
-              skipUntilNextIndent(foldedIndent)
-              if (!in.isWhitespace && in.column != foldedIndent) sb.toString
-              else readLiteral()
-            case _ =>
-              sb.append(in.read())
-              readLiteral()
+          if (in.peek() == '\u0000') sb.toString
+          else if (in.isNewline) {
+            sb.append(in.read())
+            ctx.isPlainKeyAllowed = true
+            skipUntilNextIndent(foldedIndent)
+            if (!in.isWhitespace && in.column != foldedIndent) sb.toString
+            else readLiteral()
+          } else {
+            sb.append(in.read())
+            readLiteral()
           }
 
-        val scalar        = readLiteral()
-        val chompedScalar = chompingIndicator.removeBlankLinesAtEnd(scalar)
-        queue.append(Token(Scalar(chompedScalar, ScalarStyle.Literal), range))
+        val chompedScalar = chompingIndicator.removeBlankLinesAtEnd(readLiteral())
+        queue.append(new Token(Scalar(chompedScalar, ScalarStyle.Literal), range))
       case '*' =>
-        val (name, pos) = parseAnchorName()
-        val aliasToken  = Token(Alias(name), pos)
+        val aliasToken = parseAnchorToken(true)
         if (ctx.isPlainKeyAllowed) ctx.addPotentialKey(aliasToken)
         else queue.append(aliasToken)
       case ',' =>
         in.skipCharacter()
         ctx.isPlainKeyAllowed = true
-        queue.appendAll(ctx.popPotentialKeys())
-        queue.append(Token(Comma, in.range))
-      case ':' if in.isNextWhitespace || (ctx.isInFlowCollection && ctx.isPlainKeyAllowed) =>
-        in.skipCharacter() // skip
-        val mappingValueToken = Token(MappingValue, in.range)
-        lazy val firstSimpleKey = ctx.potentialKeys.headOption.getOrElse(
-          throw ScannerError.from("Not found expected key for value", mappingValueToken)
-        )
-        if (ctx.isInBlockCollection && ctx.indent < firstSimpleKey.start.column) {
-          ctx.addIndent(firstSimpleKey.start.column)
-          queue.append(Token(MappingStart, firstSimpleKey.range))
-        }
-        val potentialKeys = ctx.popPotentialKeys()
-        ctx.isPlainKeyAllowed = false
+        queue.appendAll(ctx.popPotentialKeys()).append(new Token(Comma, in.range))
+      case '\u0000' =>
+        queue
+          .appendAll(ctx.popPotentialKeys())
+          .appendAll(ctx.checkIndents(-1))
+          .append(new Token(StreamEnd, in.range))
+      case c =>
         if (
-          ctx.isInBlockCollection &&
-          firstSimpleKey.range.end.exists(
-            _.line > firstSimpleKey.range.start.line
+          c == ':' && (in.isNextWhitespace || (ctx.isInFlowCollection && ctx.isPlainKeyAllowed))
+        ) {
+          in.skipCharacter() // skip
+          val mappingValueToken = new Token(MappingValue, in.range)
+          lazy val firstSimpleKey = ctx.potentialKeys.headOption.getOrElse(
+            throw ScannerError.from("Not found expected key for value", mappingValueToken)
           )
-        ) throw ScannerError.from("Mapping value is not allowed", mappingValueToken)
-        queue.append(Token(MappingKey, in.range))
-        queue.appendAll(potentialKeys)
-        queue.append(mappingValueToken)
-      case _ =>
-        val sb = new java.lang.StringBuilder
-
-        @tailrec
-        def readScalar(): String = {
-          val c = in.peek()
-          if (
-            c == Reader.nullTerminator ||
-            c == ':' && in.isNextWhitespace ||
-            c == ':' && in.peekNext() == ',' && ctx.isInFlowCollection ||
-            c == ' ' && in.peekNext() == '#' ||
-            c == '.' && isDocumentEnd && ctx.indent == -1 ||
-            c == '-' && isDocumentStart && ctx.indent == -1 ||
-            !ctx.isAllowedSpecialCharacter(c)
-          ) sb.toString
-          else if (c == '\n' || c == '\r' && in.peekNext() == '\n') {
-            ctx.isPlainKeyAllowed = true
-            if (in.isNextNewline) {
-              while (in.isNextNewline) {
-                in.skipCharacter()
-                sb.append('\n')
-              }
-            } else sb.append(' ')
-            skipUntilNextToken()
-            if (in.column > ctx.indent) readScalar()
-            else sb.toString
-          } else {
-            in.skipCharacter()
-            sb.append(c)
-            readScalar()
+          if (ctx.isInBlockCollection && ctx.indent < firstSimpleKey.start.column) {
+            ctx.addIndent(firstSimpleKey.start.column)
+            queue.append(new Token(MappingStart, firstSimpleKey.range))
           }
-        }
+          val potentialKeys = ctx.popPotentialKeys()
+          ctx.isPlainKeyAllowed = false
+          if (
+            ctx.isInBlockCollection &&
+            firstSimpleKey.range.end.exists(_.line > firstSimpleKey.range.start.line)
+          ) throw ScannerError.from("Mapping value is not allowed", mappingValueToken)
+          queue
+            .append(new Token(MappingKey, in.range))
+            .appendAll(potentialKeys)
+            .append(mappingValueToken)
+        } else if (c == '-' && isDocumentStart) {
+          in.skipN(if (in.peek(3) == '\u0000') 3 else 4)
+          queue.appendAll(ctx.parseDocumentStart(in.column))
+        } else if (c == '-' && in.isNextWhitespace) {
+          // when last indent is lesser than current one, it means that this is start of the sequence
+          if (ctx.isInBlockCollection && ctx.indent < in.column) {
+            ctx.addIndent(in.column)
+            queue.append(new Token(SequenceStart, in.range))
+          }
+          if (ctx.isInBlockCollection && !ctx.isPlainKeyAllowed) {
+            throw ScannerError.from(in.range, "cannot start sequence")
+          }
+          in.skipCharacter() // skip '-'
+          queue.appendAll(ctx.popPotentialKeys()).append(new Token(SequenceValue, in.range))
+        } else if (c == '.' && isDocumentEnd) {
+          in.skipN(if (in.peek(3) == '\u0000') 3 else 4)
+          queue.appendAll(ctx.parseDocumentEnd())
+        } else {
+          val sb = new java.lang.StringBuilder
 
-        val isPlainKeyAllowed = ctx.isPlainKeyAllowed
-        val range             = in.range
-        val scalar            = readScalar()
-        val endRange          = range.withEndPos(in.pos)
-        val scalarToken       = Token(Scalar(scalar.trim, ScalarStyle.Plain), endRange)
-        if (isPlainKeyAllowed) ctx.addPotentialKey(scalarToken)
-        else queue.append(scalarToken)
+          @tailrec
+          def readScalar(): String = {
+            val c = in.peek()
+            if (
+              c == '\u0000' ||
+              c == ':' && (in.isNextWhitespace || in.peek(1) == ',' && ctx.isInFlowCollection) ||
+              c == ' ' && in.peek(1) == '#' ||
+              c == '.' && ctx.indent == -1 && isDocumentEnd ||
+              c == '-' && ctx.indent == -1 && isDocumentStart ||
+              !ctx.isAllowedSpecialCharacter(c)
+            ) sb.toString
+            else if (c == '\n' || c == '\r' && in.peek(1) == '\n') {
+              ctx.isPlainKeyAllowed = true
+              if (in.isNextNewline) {
+                while (in.isNextNewline) {
+                  in.skipCharacter()
+                  sb.append('\n')
+                }
+              } else sb.append(' ')
+              skipUntilNextToken()
+              if (in.column > ctx.indent) readScalar()
+              else sb.toString
+            } else {
+              in.skipCharacter()
+              sb.append(c)
+              readScalar()
+            }
+          }
+
+          val isPlainKeyAllowed = ctx.isPlainKeyAllowed
+          val range             = in.range
+          val scalarToken =
+            new Token(Scalar(readScalar().trim, ScalarStyle.Plain), range.withEndPos(in.pos))
+          if (isPlainKeyAllowed) ctx.addPotentialKey(scalarToken)
+          else queue.append(scalarToken)
+        }
     }
   }
 
@@ -529,46 +501,51 @@ private class StringTokenizer(str: String) extends Tokenizer {
     val c1 = in.peek(1)
     val c2 = in.peek(2)
     val c3 = in.peek(3)
-    c1 == '-' && c2 == '-' && (c3.isWhitespace || c3 == Reader.nullTerminator)
+    c1 == '-' && c2 == '-' && (Character.isWhitespace(c3) || c3 == '\u0000')
   }
 
   private def isDocumentEnd = {
     val c1 = in.peek(1)
     val c2 = in.peek(2)
     val c3 = in.peek(3)
-    c1 == '.' && c2 == '.' && (c3.isWhitespace || c3 == Reader.nullTerminator)
+    c1 == '.' && c2 == '.' && (Character.isWhitespace(c3) || c3 == '\u0000')
   }
 
-  private def parseAnchorName(): (String, Range) = {
+  private def parseAnchorToken(isAlias: Boolean): Token = {
     val sb = new java.lang.StringBuilder
 
     @tailrec
-    def readAnchorName(): String =
-      in.peek() match {
-        case Reader.nullTerminator => sb.toString
-        case char
-            if !(char == '[' || char == ']' || char == '{' || char == '}' || char == ',') && !in.isWhitespace =>
-          sb.append(in.read())
-          readAnchorName()
-        case _ => sb.toString
-      }
+    def readAnchorName(): String = {
+      val c = in.peek()
+      if (c == '\u0000') sb.toString
+      else if (!(c == '[' || c == ']' || c == '{' || c == '}' || c == ',') && !in.isWhitespace) {
+        sb.append(in.read())
+        readAnchorName()
+      } else sb.toString
+    }
 
     val range = in.range
     in.skipCharacter()
     val name = readAnchorName()
-    (name, range)
+    new Token(
+      {
+        if (isAlias) new Alias(name)
+        else new Anchor(name)
+      },
+      range
+    )
   }
 
   /**
    * This header is followed by a non-content line break with an optional comment.
    */
   private def parseBlockHeader(): Unit = {
-    while (in.peek() == ' ')
-      in.skipCharacter()
-
-    if (in.peek() == '#')
-      skipComment()
-
+    var c: Char = 0
+    while ({
+      c = in.peek()
+      c == ' '
+    }) in.skipCharacter()
+    if (c == '#') skipComment()
     if (in.isNewline) in.skipCharacter()
   }
 
@@ -586,21 +563,26 @@ private class StringTokenizer(str: String) extends Tokenizer {
       case _ => BlockChompingIndicator.Clip
     }
 
-  private def parseIndentationIndicator(): Option[Int] =
-    in.peek() match {
-      case number if number.isDigit =>
-        in.skipCharacter()
-        Some(number.asDigit)
-      case _ => None
-    }
+  private def parseIndentationIndicator(): Option[Int] = {
+    val c = in.peek()
+    if (c.isDigit) {
+      in.skipCharacter()
+      new Some(c.asDigit)
+    } else None
+  }
 
   def skipUntilNextToken(): Unit = {
-    while (in.isWhitespace && !in.isNewline) in.skipCharacter()
-    if (in.peek() == '#') skipComment()
-    if (in.isNewline) {
-      ctx.isPlainKeyAllowed = true
+    var c: Char = 0
+    while ({
+      c = in.peek()
+      if (c == '#') {
+        skipComment()
+        c = in.peek()
+      }
+      Character.isWhitespace(c)
+    }) {
+      if (c == '\n' || c == '\r' && in.peek(1) == '\n') ctx.isPlainKeyAllowed = true
       in.skipCharacter()
-      skipUntilNextToken()
     }
   }
 
@@ -610,9 +592,8 @@ private class StringTokenizer(str: String) extends Tokenizer {
   def skipUntilNextIndent(indentBlock: Int): Unit =
     while (in.peek() == ' ' && in.column < indentBlock) in.skipCharacter()
 
-  def skipUntilNextChar() =
-    while (in.isWhitespace) in.skipCharacter()
+  def skipUntilNextChar() = in.skipWhitespaces()
 
-  private def skipComment(): Unit = while (in.peek() != Reader.nullTerminator && !in.isNewline)
-    in.skipCharacter()
+  private def skipComment(): Unit =
+    while (in.peek() != '\u0000' && !in.isNewline) in.skipCharacter()
 }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/Tokenizer.scala
@@ -1,18 +1,17 @@
 package org.virtuslab.yaml.internal.load.reader
 
 import scala.annotation.{switch, tailrec}
-import org.virtuslab.yaml.Range
 import org.virtuslab.yaml.ScannerError
 import org.virtuslab.yaml.YamlError
 import org.virtuslab.yaml.internal.load.TagHandle
 import org.virtuslab.yaml.internal.load.TagPrefix
 import org.virtuslab.yaml.internal.load.TagValue
 import org.virtuslab.yaml.internal.load.reader.token.BlockChompingIndicator
-import org.virtuslab.yaml.internal.load.reader.token.BlockChompingIndicator.*
+import org.virtuslab.yaml.internal.load.reader.token.BlockChompingIndicator._
 import org.virtuslab.yaml.internal.load.reader.token.ScalarStyle
 import org.virtuslab.yaml.internal.load.reader.token.Token
 import org.virtuslab.yaml.internal.load.reader.token.TokenKind
-import org.virtuslab.yaml.internal.load.reader.token.TokenKind.*
+import org.virtuslab.yaml.internal.load.reader.token.TokenKind._
 
 import scala.collection.mutable
 
@@ -465,8 +464,8 @@ private final class StringTokenizer(str: String) extends Tokenizer {
               c == '\u0000' ||
               c == ':' && (in.isNextWhitespace || in.peek(1) == ',' && ctx.isInFlowCollection) ||
               c == ' ' && in.peek(1) == '#' ||
-              c == '.' && ctx.indent == -1 && isDocumentEnd ||
-              c == '-' && ctx.indent == -1 && isDocumentStart ||
+              c == '.' && ctx.hasNoIndent && isDocumentEnd ||
+              c == '-' && ctx.hasNoIndent && isDocumentStart ||
               !ctx.isAllowedSpecialCharacter(c)
             ) sb.toString
             else if (c == '\n' || c == '\r' && in.peek(1) == '\n') {
@@ -481,8 +480,8 @@ private final class StringTokenizer(str: String) extends Tokenizer {
               if (in.column > ctx.indent) readScalar()
               else sb.toString
             } else {
-              in.skipCharacter()
               sb.append(c)
+              in.skipCharacter()
               readScalar()
             }
           }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/TokenizerContext.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/TokenizerContext.scala
@@ -35,7 +35,7 @@ private[reader] case class TokenizerContext(reader: Reader) {
   def checkIndents(current: Int): List[Token] =
     if (current < indent) {
       indentations.removeLast()
-      Token(BlockEnd, reader.range) +: checkIndents(current)
+      new Token(BlockEnd, reader.range) :: checkIndents(current)
     } else Nil
 
   def enterFlowSequence: Unit = flowSequenceLevel += 1
@@ -56,12 +56,12 @@ private[reader] case class TokenizerContext(reader: Reader) {
   def isInBlockCollection: Boolean = !isInFlowCollection
 
   def parseDocumentStart(indent: Int): List[Token] =
-    checkIndents(-1) ++ List(Token(DocumentStart, reader.range))
+    checkIndents(-1) :+ new Token(DocumentStart, reader.range)
 
   def parseDocumentEnd(): List[Token] =
-    popPotentialKeys() ++ checkIndents(-1) ++ List(Token(DocumentEnd, reader.range))
+    popPotentialKeys() ++ checkIndents(-1) :+ new Token(DocumentEnd, reader.range)
 }
 
 private[reader] object TokenizerContext {
-  def apply(in: String): TokenizerContext = TokenizerContext(new StringReader(in))
+  def apply(in: String): TokenizerContext = new TokenizerContext(new StringReader(in))
 }

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/TokenizerContext.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/TokenizerContext.scala
@@ -8,14 +8,21 @@ import org.virtuslab.yaml.internal.load.reader.token.TokenKind._
 private[reader] case class TokenizerContext(reader: Reader) {
   val tokens = mutable.ArrayDeque.empty[Token]
 
-  var isPlainKeyAllowed: Boolean = true
-  private val indentations       = mutable.ArrayDeque.empty[Int]
-  private var flowSequenceLevel  = 0
-  private var flowMappingLevel   = 0
+  var isPlainKeyAllowed: Boolean      = true
+  private[this] var indentations      = new Array[Int](8)
+  private[this] var indentationSize   = 0
+  private[this] var flowSequenceLevel = 0
+  private[this] var flowMappingLevel  = 0
 
-  def indent: Int                     = if (indentations.isEmpty) -1 else indentations.last
-  def addIndent(newIndent: Int): Unit = indentations.append(newIndent)
-  def removeLastIndent(): Unit        = if (indentations.nonEmpty) indentations.removeLast()
+  def hasNoIndent: Boolean = indentationSize == 0
+  def indent: Int          = if (indentationSize == 0) -1 else indentations(indentationSize - 1)
+  def addIndent(newIndent: Int): Unit = {
+    val i = indentationSize
+    if (i == indentations.length) indentations = java.util.Arrays.copyOf(indentations, i << 1)
+    indentations(i) = newIndent
+    indentationSize += 1
+  }
+  def removeLastIndent(): Unit = if (indentationSize > 0) indentationSize -= 1
 
   /**
     * Stores tokens which might be assosiated with simple key (scalar). Such key might start with
@@ -34,7 +41,7 @@ private[reader] case class TokenizerContext(reader: Reader) {
 
   def checkIndents(current: Int): List[Token] =
     if (current < indent) {
-      indentations.removeLast()
+      removeLastIndent()
       new Token(BlockEnd, reader.range) :: checkIndents(current)
     } else Nil
 

--- a/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/Token.scala
+++ b/core/shared/src/main/scala/org/virtuslab/yaml/internal/load/reader/token/Token.scala
@@ -36,10 +36,7 @@ object TokenKind {
   case class Scalar private (value: String, scalarStyle: ScalarStyle) extends TokenKind
 
   object Scalar {
-    def apply(scalar: String, scalarStyle: ScalarStyle = ScalarStyle.Plain) = {
-      val escapedScalar = ScalarStyle.escapeSpecialCharacter(scalar, scalarStyle)
-      new Scalar(escapedScalar, scalarStyle)
-    }
+    def apply(scalar: String, scalarStyle: ScalarStyle = ScalarStyle.Plain) =
+      new Scalar(ScalarStyle.escapeSpecialCharacter(scalar, scalarStyle), scalarStyle)
   }
-
 }

--- a/core/shared/src/test/scala-3/org/virtuslab/yaml/decoder/DecoderSuite.scala
+++ b/core/shared/src/test/scala-3/org/virtuslab/yaml/decoder/DecoderSuite.scala
@@ -494,7 +494,7 @@ class DecoderSuite extends munit.FunSuite:
       case Left(error: YamlError) =>
         fail(s"failed with YamlError: $error")
       case Right(value) =>
-        val values = value.asInstanceOf[Map[String, List[Any]]]("values")
+        val values = value.asInstanceOf[Map[String, Seq[Any]]]("values")
         val expected = List(
           Float.PositiveInfinity,
           Float.NegativeInfinity,


### PR DESCRIPTION
Below are benchmark results using Oracle GraalVM 25 on MacBook M5

Before:
```txt
[info] Benchmark                                                        (name)   Mode  Cnt        Score     Error   Units
[info] ParsingBench.fromStringToEvents                     docker-compose.yaml  thrpt   25    46736.555 ± 558.045   ops/s
[info] ParsingBench.fromStringToEvents:gc.alloc.rate       docker-compose.yaml  thrpt   25     4740.680 ±  56.544  MB/sec
[info] ParsingBench.fromStringToEvents:gc.alloc.rate.norm  docker-compose.yaml  thrpt   25   106384.126 ±   0.002    B/op
[info] ParsingBench.fromStringToEvents:gc.count            docker-compose.yaml  thrpt   25       50.000            counts
[info] ParsingBench.fromStringToEvents:gc.time             docker-compose.yaml  thrpt   25       45.000                ms
[info] ParsingBench.fromStringToEvents                                geo.yaml  thrpt   25     7797.191 ±  81.347   ops/s
[info] ParsingBench.fromStringToEvents:gc.alloc.rate                  geo.yaml  thrpt   25     5343.425 ±  55.762  MB/sec
[info] ParsingBench.fromStringToEvents:gc.alloc.rate.norm             geo.yaml  thrpt   25   718736.756 ±   0.008    B/op
[info] ParsingBench.fromStringToEvents:gc.count                       geo.yaml  thrpt   25       57.000            counts
[info] ParsingBench.fromStringToEvents:gc.time                        geo.yaml  thrpt   25       50.000                ms
[info] ParsingBench.fromStringToNode                       docker-compose.yaml  thrpt   25    39831.328 ± 182.796   ops/s
[info] ParsingBench.fromStringToNode:gc.alloc.rate         docker-compose.yaml  thrpt   25     4755.505 ±  21.984  MB/sec
[info] ParsingBench.fromStringToNode:gc.alloc.rate.norm    docker-compose.yaml  thrpt   25   125216.148 ±   0.001    B/op
[info] ParsingBench.fromStringToNode:gc.count              docker-compose.yaml  thrpt   25       50.000            counts
[info] ParsingBench.fromStringToNode:gc.time               docker-compose.yaml  thrpt   25       44.000                ms
[info] ParsingBench.fromStringToNode                                  geo.yaml  thrpt   25     4393.558 ±  20.437   ops/s
[info] ParsingBench.fromStringToNode:gc.alloc.rate                    geo.yaml  thrpt   25     6090.129 ±  28.325  MB/sec
[info] ParsingBench.fromStringToNode:gc.alloc.rate.norm               geo.yaml  thrpt   25  1453705.341 ±   0.006    B/op
[info] ParsingBench.fromStringToNode:gc.count                         geo.yaml  thrpt   25       68.000            counts
[info] ParsingBench.fromStringToNode:gc.time                          geo.yaml  thrpt   25       50.000                ms
[info] ParsingBench.fromStringToStruct                     docker-compose.yaml  thrpt   25    30661.500 ± 183.371   ops/s
[info] ParsingBench.fromStringToStruct:gc.alloc.rate       docker-compose.yaml  thrpt   25     5198.347 ±  45.195  MB/sec
[info] ParsingBench.fromStringToStruct:gc.alloc.rate.norm  docker-compose.yaml  thrpt   25   177803.392 ± 792.030    B/op
[info] ParsingBench.fromStringToStruct:gc.count            docker-compose.yaml  thrpt   25       59.000            counts
[info] ParsingBench.fromStringToStruct:gc.time             docker-compose.yaml  thrpt   25       51.000                ms
[info] ParsingBench.fromStringToStruct                                geo.yaml  thrpt   25     2738.700 ±  13.551   ops/s
[info] ParsingBench.fromStringToStruct:gc.alloc.rate                  geo.yaml  thrpt   25     7480.484 ±  37.146  MB/sec
[info] ParsingBench.fromStringToStruct:gc.alloc.rate.norm             geo.yaml  thrpt   25  2864496.856 ±  57.681    B/op
[info] ParsingBench.fromStringToStruct:gc.count                       geo.yaml  thrpt   25       81.000            counts
[info] ParsingBench.fromStringToStruct:gc.time                        geo.yaml  thrpt   25       46.000                ms
```

After:
```txt
[info] Benchmark                                                        (name)   Mode  Cnt        Score     Error   Units
[info] ParsingBench.fromStringToEvents                     docker-compose.yaml  thrpt   25    55977.332 ± 298.644   ops/s
[info] ParsingBench.fromStringToEvents:gc.alloc.rate       docker-compose.yaml  thrpt   25     5656.691 ±  30.228  MB/sec
[info] ParsingBench.fromStringToEvents:gc.alloc.rate.norm  docker-compose.yaml  thrpt   25   105984.105 ±   0.001    B/op
[info] ParsingBench.fromStringToEvents:gc.count            docker-compose.yaml  thrpt   25       60.000            counts
[info] ParsingBench.fromStringToEvents:gc.time             docker-compose.yaml  thrpt   25       37.000                ms
[info] ParsingBench.fromStringToEvents                                geo.yaml  thrpt   25     7755.329 ±  55.361   ops/s
[info] ParsingBench.fromStringToEvents:gc.alloc.rate                  geo.yaml  thrpt   25     5311.990 ±  37.928  MB/sec
[info] ParsingBench.fromStringToEvents:gc.alloc.rate.norm             geo.yaml  thrpt   25   718368.759 ±   0.006    B/op
[info] ParsingBench.fromStringToEvents:gc.count                       geo.yaml  thrpt   25       56.000            counts
[info] ParsingBench.fromStringToEvents:gc.time                        geo.yaml  thrpt   25       47.000                ms
[info] ParsingBench.fromStringToNode                       docker-compose.yaml  thrpt   25    48454.088 ± 168.912   ops/s
[info] ParsingBench.fromStringToNode:gc.alloc.rate         docker-compose.yaml  thrpt   25     5437.207 ±  18.964  MB/sec
[info] ParsingBench.fromStringToNode:gc.alloc.rate.norm    docker-compose.yaml  thrpt   25   117688.121 ±   0.001    B/op
[info] ParsingBench.fromStringToNode:gc.count              docker-compose.yaml  thrpt   25       60.000            counts
[info] ParsingBench.fromStringToNode:gc.time               docker-compose.yaml  thrpt   25       41.000                ms
[info] ParsingBench.fromStringToNode                                  geo.yaml  thrpt   25     4354.844 ±  15.967   ops/s
[info] ParsingBench.fromStringToNode:gc.alloc.rate                    geo.yaml  thrpt   25     6032.219 ±  22.210  MB/sec
[info] ParsingBench.fromStringToNode:gc.alloc.rate.norm               geo.yaml  thrpt   25  1452705.352 ±   0.005    B/op
[info] ParsingBench.fromStringToNode:gc.count                         geo.yaml  thrpt   25       68.000            counts
[info] ParsingBench.fromStringToNode:gc.time                          geo.yaml  thrpt   25       53.000                ms
[info] ParsingBench.fromStringToStruct                     docker-compose.yaml  thrpt   25    36156.194 ± 116.783   ops/s
[info] ParsingBench.fromStringToStruct:gc.alloc.rate       docker-compose.yaml  thrpt   25     5828.650 ±  18.286  MB/sec
[info] ParsingBench.fromStringToStruct:gc.alloc.rate.norm  docker-compose.yaml  thrpt   25   169067.363 ±  40.865    B/op
[info] ParsingBench.fromStringToStruct:gc.count            docker-compose.yaml  thrpt   25       60.000            counts
[info] ParsingBench.fromStringToStruct:gc.time             docker-compose.yaml  thrpt   25       46.000                ms
[info] ParsingBench.fromStringToStruct                                geo.yaml  thrpt   25     2730.227 ±   9.010   ops/s
[info] ParsingBench.fromStringToStruct:gc.alloc.rate                  geo.yaml  thrpt   25     7454.276 ±  24.591  MB/sec
[info] ParsingBench.fromStringToStruct:gc.alloc.rate.norm             geo.yaml  thrpt   25  2863357.667 ±  41.049    B/op
[info] ParsingBench.fromStringToStruct:gc.count                       geo.yaml  thrpt   25       80.000            counts
[info] ParsingBench.fromStringToStruct:gc.time                        geo.yaml  thrpt   25       46.000                ms
```